### PR TITLE
Fix ReactFlow import path

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This prototype uses **React 18**, **TypeScript 5** and **Vite**. It provides a simple interface with:
 
 - Palette bar with tool buttons
-- Graph canvas powered by `react-flow-renderer`
+- Graph canvas powered by `reactflow`
 - Properties panel with a Formik form
 - State management via Redux Toolkit
 

--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -1,4 +1,4 @@
-import ReactFlow, { Background, Controls, MiniMap, Node, Edge } from 'react-flow-renderer'
+import ReactFlow, { Background, Controls, MiniMap, Node, Edge } from 'reactflow'
 import { useAppDispatch, useAppSelector } from '../hooks'
 import { addNode, addEdge, setElements, select } from '../features/network/networkSlice'
 import { useCallback } from 'react'

--- a/src/features/network/networkSlice.ts
+++ b/src/features/network/networkSlice.ts
@@ -1,5 +1,5 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
-import { Node, Edge } from 'react-flow-renderer'
+import { Node, Edge } from 'reactflow'
 import { NetworkState } from './types'
 
 const initialState: NetworkState = {

--- a/src/features/network/types.ts
+++ b/src/features/network/types.ts
@@ -1,4 +1,4 @@
-import { Node, Edge } from 'react-flow-renderer'
+import { Node, Edge } from 'reactflow'
 
 export interface NetworkState {
   nodes: Node[]


### PR DESCRIPTION
## Summary
- use `reactflow` package name in imports
- update README to mention `reactflow`

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_686cad4d191c832ca98ca1becfbf2b64