### PR TITLE
Fix palette icons visibility

### DIFF
--- a/src/components/PaletteButton.tsx
+++ b/src/components/PaletteButton.tsx
@@ -31,8 +31,15 @@ export default function PaletteButton({ icon: Icon, label, type, ring }: Palette
       )}
     >
       <span className="relative">
-        <Icon className="w-5 h-5 pointer-events-none" />
-        {ring && <span className="absolute inset-0 rounded-full ring-2 ring-current" />}
+        <Icon
+          className={classNames(
+            'w-5 h-5 pointer-events-none text-gray-600',
+            { 'text-white': active }
+          )}
+        />
+        {ring && (
+          <span className="absolute inset-0 rounded-full ring-2 ring-current pointer-events-none" />
+        )}
       </span>
     </button>
   )


### PR DESCRIPTION
## Summary
- ensure tailwind heroicon buttons have visible icons by giving them default text color and pointer-events disabled ring
- build project to confirm

## Testing
- `npm run build`
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_686cd3300c94832c85fab50acb2687b3