### PR TITLE
Update icons and map

### DIFF
--- a/src/components/MapBackground.tsx
+++ b/src/components/MapBackground.tsx
@@ -1,4 +1,10 @@
-import { ComposableMap, Geographies, Geography, Marker } from 'react-simple-maps'
+import {
+  ComposableMap,
+  Geographies,
+  Geography,
+  Marker,
+  ZoomableGroup,
+} from 'react-simple-maps'
 import { useViewport } from 'reactflow'
 import russia from '../assets/RUS.geo.json'
 
@@ -15,7 +21,7 @@ export default function MapBackground() {
 
   return (
     <div
-      className="absolute inset-0 w-full h-full pointer-events-none"
+      className="absolute inset-0 w-full h-full overflow-hidden pointer-events-none"
       style={{
         transform: `translate(${x}px, ${y}px) scale(${zoom})`,
         transformOrigin: '0 0',
@@ -25,32 +31,39 @@ export default function MapBackground() {
         width={1000}
         height={700}
         projection="geoMercator"
-        projectionConfig={{ scale: 420, center: [105, 60] }}
         style={{ width: '100%', height: '100%' }}
       >
-        <Geographies geography={russia as any}>
-          {({ geographies }) =>
-            geographies.map(geo => (
-              <Geography
-                key={geo.rsmKey}
-                geography={geo}
-                style={{ default: { fill: 'none', stroke: '#000', strokeWidth: 1 } }}
-              />
-            ))
-          }
-        </Geographies>
-        {cities.map(c => (
-          <Marker key={c.name} coordinates={c.coords as any}>
-            <circle r={5} fill="#dc2626" stroke="#fff" strokeWidth={1} />
-            <text
-              textAnchor="middle"
-              y={-8}
-              style={{ fontSize: 12, fill: '#dc2626' }}
-            >
-              {c.name}
-            </text>
-          </Marker>
-        ))}
+        <ZoomableGroup
+          fitWidth
+          fitHeight
+          translateExtent={[[-180, -90], [180, 90]]}
+          projectionScale={400}
+          projectionTranslate={[500, 350]}
+        >
+          <Geographies geography={russia as any}>
+            {({ geographies }) =>
+              geographies.map(geo => (
+                <Geography
+                  key={geo.rsmKey}
+                  geography={geo}
+                  style={{ default: { fill: 'none', stroke: '#000', strokeWidth: 1 } }}
+                />
+              ))
+            }
+          </Geographies>
+          {cities.map(c => (
+            <Marker key={c.name} coordinates={c.coords as any}>
+              <circle r={5} fill="#dc2626" stroke="#fff" strokeWidth={1} />
+              <text
+                textAnchor="middle"
+                y={-8}
+                style={{ fontSize: 12, fill: '#dc2626' }}
+              >
+                {c.name}
+              </text>
+            </Marker>
+          ))}
+        </ZoomableGroup>
       </ComposableMap>
     </div>
   )

--- a/src/components/PaletteBar.tsx
+++ b/src/components/PaletteBar.tsx
@@ -1,32 +1,20 @@
 import PaletteButton from './PaletteButton'
 import {
-  CubeIcon,
-  CubeTransparentIcon,
+  RocketLaunchIcon as SatelliteIcon,
   HomeModernIcon,
   ArrowRightIcon,
+  MinusCircleIcon,
+  PlusCircleIcon,
 } from '@heroicons/react/24/solid'
-
-const items = [
-  { type: 'leo', icon: CubeIcon, label: 'LEO' },
-  { type: 'meo', icon: CubeTransparentIcon, label: 'MEO' },
-  { type: 'geo', icon: CubeIcon, label: 'GEO', ring: true },
-  { type: 'gnd', icon: HomeModernIcon, label: 'GND' },
-  { type: 'link', icon: ArrowRightIcon, label: 'LINK' },
-]
 
 export default function PaletteBar() {
   return (
-    <div className="sticky top-0 z-10 bg-white flex items-center px-4 h-14">
-      <div className="font-bold mr-auto">SAT-NET</div>
-      {items.map(item => (
-        <PaletteButton
-          key={item.type}
-          icon={item.icon}
-          label={item.label}
-          type={item.type}
-          ring={'ring' in item ? item.ring : undefined}
-        />
-      ))}
+    <div className="fixed top-0 right-3 flex gap-2">
+      <PaletteButton icon={SatelliteIcon} type="LEO" />
+      <PaletteButton icon={MinusCircleIcon} type="MEO" />
+      <PaletteButton icon={PlusCircleIcon} type="GEO" />
+      <PaletteButton icon={HomeModernIcon} type="GND" />
+      <PaletteButton icon={ArrowRightIcon} type="LINK" />
     </div>
   )
 }

--- a/src/components/PaletteButton.tsx
+++ b/src/components/PaletteButton.tsx
@@ -1,16 +1,13 @@
 import { ComponentType, SVGProps } from 'react'
-import classNames from 'classnames'
 import { useAppDispatch, useAppSelector } from '../hooks'
 import { setAddingType } from '../features/network/networkSlice'
 
 interface PaletteButtonProps {
   icon: ComponentType<SVGProps<SVGSVGElement>>
-  label: string
   type: string
-  ring?: boolean
 }
 
-export default function PaletteButton({ icon: Icon, label, type, ring }: PaletteButtonProps) {
+export default function PaletteButton({ icon: Icon, type }: PaletteButtonProps) {
   const dispatch = useAppDispatch()
   const addingType = useAppSelector(state => state.network.addingType)
   const active = addingType === type
@@ -18,29 +15,17 @@ export default function PaletteButton({ icon: Icon, label, type, ring }: Palette
   return (
     <button
       type="button"
-      title={label}
+      className={`w-10 h-10 flex items-center justify-center rounded ${
+        active ? 'bg-blue-500 text-white' : 'bg-gray-100 hover:bg-gray-200'
+      }`}
       draggable
       onDragStart={e => {
         e.dataTransfer.setData('application/reactflow', type)
         e.dataTransfer.effectAllowed = 'move'
       }}
       onClick={() => dispatch(setAddingType(active ? null : type))}
-      className={classNames(
-        'flex items-center justify-center w-10 h-10 rounded bg-gray-100 hover:bg-gray-200 mr-2',
-        { 'bg-blue-500 text-white': active }
-      )}
     >
-      <span className="relative">
-        <Icon
-          className={classNames(
-            'w-5 h-5 pointer-events-none text-gray-600',
-            { 'text-white': active }
-          )}
-        />
-        {ring && (
-          <span className="absolute inset-0 rounded-full ring-2 ring-current pointer-events-none" />
-        )}
-      </span>
+      <Icon className="w-6 h-6" />
     </button>
   )
 }

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,7 +1,7 @@
 module.exports = {
   content: [
     './index.html',
-    './src/**/*.{ts,tsx}'
+    './src/**/*.{js,ts,jsx,tsx}'
   ],
   theme: {
     extend: {},


### PR DESCRIPTION
## Summary
- update tailwind content glob
- use heroicons icons for palette bar
- simplify PaletteButton component
- adjust map background with ZoomableGroup

## Testing
- `npm run build`
- `npm test` *(fails: No test files found)*
- `npm run dev` *(started local server)*

------
https://chatgpt.com/codex/tasks/task_e_686cd885886c832c8b92421dc9238b67