### PR TITLE
Add dynamic node and link properties panel

### DIFF
--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -5,6 +5,7 @@ import ReactFlow, {
   Edge,
   NodeChange,
   EdgeChange,
+  Connection,
   applyNodeChanges,
   applyEdgeChanges,
   useReactFlow,
@@ -27,7 +28,16 @@ export default function Canvas() {
   const reactFlow = useReactFlow()
   const [linkSource, setLinkSource] = useState<string | null>(null)
 
-  const onConnect = useCallback((params: Edge) => dispatch(addEdge(params)), [dispatch])
+  const onConnect = useCallback((params: Connection) => {
+    dispatch(
+      addEdge({
+        id: `${params.source}-${params.target}-${Date.now()}`,
+        source: params.source!,
+        target: params.target!,
+        style: { stroke: 'black' },
+      })
+    )
+  }, [dispatch])
 
   const onNodesChange = useCallback(
     (changes: NodeChange[]) => {
@@ -103,9 +113,11 @@ export default function Canvas() {
               dispatch(setAddingType(null))
               toast.success('Связь создана')
             }
+          } else {
+            dispatch(select(node.id))
           }
         }}
-        onNodeDoubleClick={(_, node) => dispatch(select(node.id))}
+        onEdgeClick={(_, edge) => addingType !== 'link' && dispatch(select(edge.id))}
         fitView
         snapToGrid
         snapGrid={[25, 25]}

--- a/src/components/PropertiesPanel.tsx
+++ b/src/components/PropertiesPanel.tsx
@@ -1,41 +1,118 @@
 import { Formik, Form, Field } from 'formik'
 import * as Yup from 'yup'
 import { useAppDispatch, useAppSelector } from '../hooks'
-import { updateNode, select } from '../features/network/networkSlice'
+import { updateNode, updateEdge, select } from '../features/network/networkSlice'
 import toast from 'react-hot-toast'
 
 export default function PropertiesPanel() {
   const dispatch = useAppDispatch()
-  const { nodes, selectedId } = useAppSelector(state => state.network)
+  const { nodes, edges, selectedId } = useAppSelector(state => state.network)
+
   const node = nodes.find(n => n.id === selectedId)
+  const edge = edges.find(e => e.id === selectedId)
 
-  if (!node) return null
+  if (!node && !edge) return null
 
-  return (
-    <div className="bg-white border-l px-4 py-6 overflow-y-auto" data-testid="properties-panel">
-      <div className="font-semibold mb-4">
-        {node.type} • {node.id}
+  if (node) {
+    const isSatellite = ['leo', 'meo', 'geo'].includes(node.type || '')
+    const isGround = node.type === 'gnd'
+    const initialValues: any = {
+      label: node.data?.label || '',
+    }
+    if (isSatellite) initialValues.altitude = node.data?.altitude || ''
+    if (isGround) initialValues.location = node.data?.location || ''
+
+    const schemaShape: any = { label: Yup.string().required() }
+    if (isSatellite) schemaShape.altitude = Yup.number().required()
+    if (isGround) schemaShape.location = Yup.string().required()
+
+    return (
+      <div className="bg-white border-l px-4 py-6 overflow-y-auto" data-testid="properties-panel">
+        <div className="font-semibold mb-4">
+          {node.type} • {node.id}
+        </div>
+        <Formik
+          initialValues={initialValues}
+          validationSchema={Yup.object(schemaShape)}
+          onSubmit={values => {
+            dispatch(updateNode({ ...node, data: { ...node.data, ...values } }))
+            dispatch(select(null))
+            toast.success('Свойства сохранены')
+          }}
+        >
+          {() => (
+            <Form className="flex flex-col gap-2">
+              <label className="text-sm">Label</label>
+              <Field name="label" className="border rounded p-1" />
+              {isSatellite && (
+                <>
+                  <label className="text-sm">Altitude</label>
+                  <Field name="altitude" type="number" className="border rounded p-1" />
+                </>
+              )}
+              {isGround && (
+                <>
+                  <label className="text-sm">Location</label>
+                  <Field name="location" className="border rounded p-1" />
+                </>
+              )}
+              <div className="flex justify-end gap-2 mt-4">
+                <button type="submit" className="px-3 py-1 bg-blue-500 text-white rounded">Save</button>
+                <button type="button" onClick={() => dispatch(select(null))} className="px-3 py-1 border rounded">Close</button>
+              </div>
+            </Form>
+          )}
+        </Formik>
       </div>
-      <Formik
-        initialValues={{ label: node.data?.label || '' }}
-        validationSchema={Yup.object({ label: Yup.string().required() })}
-        onSubmit={values => {
-          dispatch(updateNode({ ...node, data: { ...node.data, label: values.label } }))
-          dispatch(select(null))
-          toast.success('Свойства сохранены')
-        }}
-      >
-        {() => (
-          <Form className="flex flex-col gap-2">
-            <label className="text-sm">Label</label>
-            <Field name="label" className="border rounded p-1" />
-            <div className="flex justify-end gap-2 mt-4">
-              <button type="submit" className="px-3 py-1 bg-blue-500 text-white rounded">Save</button>
-              <button type="button" onClick={() => dispatch(select(null))} className="px-3 py-1 border rounded">Close</button>
-            </div>
-          </Form>
-        )}
-      </Formik>
-    </div>
-  )
+    )
+  }
+
+  if (edge) {
+    const initialValues = {
+      label: (edge as any).label || '',
+      bandwidth: edge.data?.bandwidth || '',
+      latency: edge.data?.latency || '',
+    }
+    return (
+      <div className="bg-white border-l px-4 py-6 overflow-y-auto" data-testid="properties-panel">
+        <div className="font-semibold mb-4">LINK • {edge.id}</div>
+        <Formik
+          initialValues={initialValues}
+          validationSchema={Yup.object({
+            bandwidth: Yup.number().required(),
+            latency: Yup.number().required(),
+            label: Yup.string(),
+          })}
+          onSubmit={values => {
+            dispatch(
+              updateEdge({
+                ...edge,
+                label: values.label,
+                data: { ...edge.data, bandwidth: values.bandwidth, latency: values.latency },
+              })
+            )
+            dispatch(select(null))
+            toast.success('Свойства сохранены')
+          }}
+        >
+          {() => (
+            <Form className="flex flex-col gap-2">
+              <label className="text-sm">Label</label>
+              <Field name="label" className="border rounded p-1" />
+              <label className="text-sm">Bandwidth (Mbps)</label>
+              <Field name="bandwidth" type="number" className="border rounded p-1" />
+              <label className="text-sm">Latency (ms)</label>
+              <Field name="latency" type="number" className="border rounded p-1" />
+              <div className="flex justify-end gap-2 mt-4">
+                <button type="submit" className="px-3 py-1 bg-blue-500 text-white rounded">Save</button>
+                <button type="button" onClick={() => dispatch(select(null))} className="px-3 py-1 border rounded">Close</button>
+              </div>
+            </Form>
+          )}
+        </Formik>
+      </div>
+    )
+  }
+
+  return null
 }

--- a/src/features/network/networkSlice.ts
+++ b/src/features/network/networkSlice.ts
@@ -27,6 +27,10 @@ const networkSlice = createSlice({
       const idx = state.nodes.findIndex(n => n.id === action.payload.id)
       if (idx !== -1) state.nodes[idx] = action.payload
     },
+    updateEdge(state, action: PayloadAction<Edge>) {
+      const idx = state.edges.findIndex(e => e.id === action.payload.id)
+      if (idx !== -1) state.edges[idx] = action.payload
+    },
     removeElement(state, action: PayloadAction<string>) {
       state.nodes = state.nodes.filter(n => n.id !== action.payload)
       state.edges = state.edges.filter(e => e.id !== action.payload && e.source !== action.payload && e.target !== action.payload)
@@ -45,6 +49,7 @@ export const {
   addNode,
   addEdge,
   updateNode,
+  updateEdge,
   removeElement,
   select,
   setAddingType,


### PR DESCRIPTION
## Summary
- allow React Flow edges to be updated by introducing `updateEdge`
- open properties panel on node or edge click
- display different forms depending on node type
- support editing link characteristics

## Testing
- `npx tsc --noEmit`
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_686dec3119f4832cbbfcf5e7d26f5b15