### PR TITLE
Update node move logic and map scale

### DIFF
--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -19,7 +19,13 @@ import {
   select,
   setAddingType,
 } from '../features/network/networkSlice'
-import { latLonToPos, posToLatLon, distanceKm } from '../utils/geo'
+import {
+  latLonToPos,
+  posToLatLon,
+  distanceKm,
+  SCALE,
+  updateEdgesDistances,
+} from '../utils/geo'
 import { useCallback, useEffect, useState } from 'react'
 import toast from 'react-hot-toast'
 
@@ -58,7 +64,8 @@ export default function Canvas() {
         const { lat, lon } = posToLatLon(n.position)
         return { ...n, data: { ...n.data, lat, lon } }
       })
-      dispatch(setElements({ nodes: updatedNodes, edges }))
+      const updatedEdges = updateEdgesDistances(updatedNodes, edges)
+      dispatch(setElements({ nodes: updatedNodes, edges: updatedEdges }))
     },
     [dispatch, nodes, edges]
   )
@@ -109,7 +116,7 @@ export default function Canvas() {
       onDragOver={onDragOver}
     >
       <ReactFlow
-        style={{ width: 1800, height: 900 }}
+        style={{ width: 360 * SCALE, height: 180 * SCALE }}
         nodes={nodes}
         edges={edges}
         onNodesChange={onNodesChange}
@@ -153,7 +160,7 @@ export default function Canvas() {
         onEdgeClick={(_, edge) => addingType !== 'link' && dispatch(select(edge.id))}
         fitView
         snapToGrid
-        snapGrid={[25, 25]}
+        snapGrid={[SCALE / 60, SCALE / 60]}
         defaultViewport={{ x: 0, y: 0, zoom: 1 }}
         proOptions={{ hideAttribution: true }}
       >

--- a/src/components/PropertiesPanel.tsx
+++ b/src/components/PropertiesPanel.tsx
@@ -1,8 +1,13 @@
 import { Formik, Form, Field } from 'formik'
 import * as Yup from 'yup'
 import { useAppDispatch, useAppSelector } from '../hooks'
-import { updateNode, updateEdge, select } from '../features/network/networkSlice'
-import { latLonToPos } from '../utils/geo'
+import {
+  updateNode,
+  updateEdge,
+  select,
+  setElements,
+} from '../features/network/networkSlice'
+import { latLonToPos, updateEdgesDistances } from '../utils/geo'
 import toast from 'react-hot-toast'
 
 export default function PropertiesPanel() {
@@ -43,8 +48,26 @@ export default function PropertiesPanel() {
           enableReinitialize
           validationSchema={Yup.object(schemaShape)}
           onSubmit={values => {
-            const position = latLonToPos(Number(values.lat), Number(values.lon))
-            dispatch(updateNode({ ...node, position, data: { ...node.data, ...values, lat: Number(values.lat), lon: Number(values.lon) } }))
+            const position = latLonToPos(
+              Number(values.lat),
+              Number(values.lon)
+            )
+            const updatedNodes = nodes.map(n =>
+              n.id === node.id
+                ? {
+                    ...node,
+                    position,
+                    data: {
+                      ...node.data,
+                      ...values,
+                      lat: Number(values.lat),
+                      lon: Number(values.lon),
+                    },
+                  }
+                : n
+            )
+            const updatedEdges = updateEdgesDistances(updatedNodes, edges)
+            dispatch(setElements({ nodes: updatedNodes, edges: updatedEdges }))
             dispatch(select(null))
             toast.success('Свойства сохранены')
           }}

--- a/src/utils/geo.ts
+++ b/src/utils/geo.ts
@@ -1,4 +1,4 @@
-export const SCALE = 5
+export const SCALE = 300
 
 /**
  * Convert positive latitude/longitude values to canvas position.
@@ -45,4 +45,30 @@ export function distanceKm(
     Math.cos(lat1r) * Math.cos(lat2r) * Math.sin(dLon / 2) ** 2
   const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
   return EARTH_RADIUS_KM * c
+}
+
+import type { Node, Edge } from 'reactflow'
+
+/**
+ * Recalculate edge distances based on current node coordinates.
+ */
+export function updateEdgesDistances(nodes: Node[], edges: Edge[]): Edge[] {
+  return edges.map(e => {
+    const src = nodes.find(n => n.id === e.source)
+    const tgt = nodes.find(n => n.id === e.target)
+    if (src?.data && tgt?.data) {
+      const distance = distanceKm(
+        src.data.lat,
+        src.data.lon,
+        tgt.data.lat,
+        tgt.data.lon
+      )
+      return {
+        ...e,
+        data: { ...e.data, distance },
+        label: `${Math.round(distance)} km`,
+      }
+    }
+    return e
+  })
 }


### PR DESCRIPTION
## Summary
- recalc link distance when nodes move
- include helper to recompute edge distances
- enlarge map scale to use minute precision
- update properties panel to refresh edges on save

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_686df995be34832ca35091f8836087d2