### PR TITLE
Add zoomed-out icons for nodes

### DIFF
--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -28,6 +28,7 @@ import {
 } from '../utils/geo'
 import { useCallback, useEffect, useState } from 'react'
 import toast from 'react-hot-toast'
+import NetworkNode from './NetworkNode'
 
 export default function Canvas() {
   const dispatch = useAppDispatch()
@@ -119,6 +120,8 @@ export default function Canvas() {
         style={{ width: 360 * SCALE, height: 180 * SCALE }}
         nodes={nodes}
         edges={edges}
+        nodeTypes={{ leo: NetworkNode, meo: NetworkNode, geo: NetworkNode, gnd: NetworkNode }}
+        minZoom={0.05}
         onNodesChange={onNodesChange}
         onEdgesChange={onEdgesChange}
         onConnect={onConnect}

--- a/src/components/NetworkNode.tsx
+++ b/src/components/NetworkNode.tsx
@@ -1,0 +1,46 @@
+import { NodeProps, useStoreState } from 'reactflow'
+import { CubeIcon, CubeTransparentIcon, HomeModernIcon } from '@heroicons/react/24/solid'
+import classNames from 'classnames'
+
+const typeIcons: Record<string, React.ComponentType<any>> = {
+  leo: CubeIcon,
+  meo: CubeTransparentIcon,
+  geo: CubeIcon,
+  gnd: HomeModernIcon,
+}
+
+export default function NetworkNode({ data, type, selected, className }: NodeProps<any>) {
+  const zoom = useStoreState(state => state.transform[2])
+  const Icon = typeIcons[type] || CubeIcon
+  const ring = type === 'geo'
+
+  if (zoom < 0.3) {
+    return (
+      <div
+        className={classNames(
+          'flex items-center justify-center rounded-full bg-white border',
+          { 'ring-1 ring-current': ring },
+          { 'ring-2 ring-blue-500': selected },
+          className
+        )}
+        style={{ width: 8, height: 8 }}
+      >
+        <Icon className="w-2 h-2" />
+      </div>
+    )
+  }
+
+  return (
+    <div
+      className={classNames(
+        'bg-white border rounded px-2 py-1 text-xs flex items-center gap-1',
+        { 'ring-1 ring-current': ring },
+        { 'ring-2 ring-blue-500': selected },
+        className
+      )}
+    >
+      <Icon className="w-4 h-4" />
+      <span>{data?.label}</span>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- show nodes as icons with `NetworkNode` component
- allow stronger zoom out so the map fits ~8000km across screen
- use new node type renderer in `Canvas`

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_686dfe306280832c989cc7e8cdaa6f9e