### PR TITLE
Add delete tool

### DIFF
--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -16,6 +16,7 @@ import {
   addEdge,
   setElements,
   updateNode,
+  removeElement,
   select,
   setAddingType,
 } from '../features/network/networkSlice'
@@ -123,7 +124,10 @@ export default function Canvas() {
         onEdgesChange={onEdgesChange}
         onConnect={onConnect}
         onNodeClick={(_, node) => {
-          if (addingType === 'link') {
+          if (addingType === 'delete') {
+            dispatch(removeElement(node.id))
+            toast.success('Удалено')
+          } else if (addingType === 'link') {
             if (!linkSource) {
               setLinkSource(node.id)
               dispatch(updateNode({ ...node, className: 'ring-2 ring-blue-500' }))
@@ -157,7 +161,14 @@ export default function Canvas() {
             dispatch(select(node.id))
           }
         }}
-        onEdgeClick={(_, edge) => addingType !== 'link' && dispatch(select(edge.id))}
+        onEdgeClick={(_, edge) => {
+          if (addingType === 'delete') {
+            dispatch(removeElement(edge.id))
+            toast.success('Удалено')
+          } else if (addingType !== 'link') {
+            dispatch(select(edge.id))
+          }
+        }}
         fitView
         snapToGrid
         snapGrid={[SCALE / 60, SCALE / 60]}

--- a/src/components/PaletteBar.tsx
+++ b/src/components/PaletteBar.tsx
@@ -4,6 +4,7 @@ import {
   CubeTransparentIcon,
   HomeModernIcon,
   ArrowRightIcon,
+  TrashIcon,
 } from "@heroicons/react/24/solid";
 
 const items = [
@@ -12,6 +13,7 @@ const items = [
   { type: "geo", icon: CubeIcon, label: "GEO", ring: true },
   { type: "gnd", icon: HomeModernIcon, label: "GND" },
   { type: "link", icon: ArrowRightIcon, label: "LINK" },
+  { type: "delete", icon: TrashIcon, label: "DEL" },
 ];
 
 export default function PaletteBar() {


### PR DESCRIPTION
## Summary
- add a Trash tool in PaletteBar
- allow deleting nodes or links when delete mode is active

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_686e1579e558832cb390b5d293c02002