### PR TITLE
Fix node type registration for React Flow

### DIFF
--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -10,6 +10,8 @@ import ReactFlow, {
   applyEdgeChanges,
   useReactFlow,
 } from 'reactflow'
+import type { NodeTypes } from 'reactflow'
+import NetworkNode from './NetworkNode'
 import { useAppDispatch, useAppSelector } from '../hooks'
 import {
   addNode,
@@ -29,6 +31,13 @@ import {
 } from '../utils/geo'
 import { useCallback, useEffect, useState } from 'react'
 import toast from 'react-hot-toast'
+
+const nodeTypes: NodeTypes = {
+  leo: NetworkNode,
+  meo: NetworkNode,
+  geo: NetworkNode,
+  gnd: NetworkNode,
+}
 
 export default function Canvas() {
   const dispatch = useAppDispatch()
@@ -120,6 +129,7 @@ export default function Canvas() {
         style={{ width: 360 * SCALE, height: 180 * SCALE }}
         nodes={nodes}
         edges={edges}
+        nodeTypes={nodeTypes}
         onNodesChange={onNodesChange}
         onEdgesChange={onEdgesChange}
         onConnect={onConnect}


### PR DESCRIPTION
## Summary
- register all node types with ReactFlow so custom nodes render

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e3347c658832cb3c92e6edadebe40