### PR TITLE
Add HAPS object

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This prototype uses **React 18**, **TypeScript 5** and **Vite**. It provides a simple interface with:
 
-- Palette bar with tool buttons
+- Palette bar with tool buttons, including a HAPS (High Altitude Platform Station) node
 - Graph canvas powered by `reactflow`
 - Properties panel with a Formik form
 - State management via Redux Toolkit

--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -37,6 +37,7 @@ const nodeTypes: NodeTypes = {
   meo: NetworkNode,
   geo: NetworkNode,
   gnd: NetworkNode,
+  haps: NetworkNode,
 }
 
 export default function Canvas() {

--- a/src/components/NetworkNode.tsx
+++ b/src/components/NetworkNode.tsx
@@ -1,5 +1,10 @@
 import { NodeProps, useStore, Handle, Position } from 'reactflow'
-import { CubeIcon, CubeTransparentIcon, HomeModernIcon } from '@heroicons/react/24/solid'
+import {
+  CubeIcon,
+  CubeTransparentIcon,
+  HomeModernIcon,
+  PaperAirplaneIcon,
+} from '@heroicons/react/24/solid'
 import classNames from 'classnames'
 
 const typeIcons: Record<string, React.ComponentType<any>> = {
@@ -7,6 +12,7 @@ const typeIcons: Record<string, React.ComponentType<any>> = {
   meo: CubeTransparentIcon,
   geo: CubeIcon,
   gnd: HomeModernIcon,
+  haps: PaperAirplaneIcon,
 }
 
 export default function NetworkNode({ data, type, selected, className }: NodeProps<any>) {

--- a/src/components/PaletteBar.tsx
+++ b/src/components/PaletteBar.tsx
@@ -3,6 +3,7 @@ import {
   CubeIcon,
   CubeTransparentIcon,
   HomeModernIcon,
+  PaperAirplaneIcon,
   ArrowRightIcon,
 } from "@heroicons/react/24/solid";
 
@@ -11,6 +12,7 @@ const items = [
   { type: "meo", icon: CubeTransparentIcon, label: "Средняя орбита" },
   { type: "geo", icon: CubeIcon, label: "Геостационарная орбита", ring: true },
   { type: "gnd", icon: HomeModernIcon, label: "Наземная станция" },
+  { type: "haps", icon: PaperAirplaneIcon, label: "Высотная платформа" },
   { type: "link", icon: ArrowRightIcon, label: "Связь" },
 ];
 

--- a/src/components/PropertiesPanel.tsx
+++ b/src/components/PropertiesPanel.tsx
@@ -17,6 +17,7 @@ const typeNames: Record<string, string> = {
   meo: 'Средняя орбита',
   geo: 'Геостационарная орбита',
   gnd: 'Наземная станция',
+  haps: 'Высотная платформа',
 }
 
 function NodePositionUpdater({ node }: { node: Node }) {
@@ -61,7 +62,7 @@ export default function PropertiesPanel() {
   if (!node && !edge) return null
 
   if (node) {
-    const isSatellite = ['leo', 'meo', 'geo'].includes(node.type || '')
+    const isSatellite = ['leo', 'meo', 'geo', 'haps'].includes(node.type || '')
     const isGround = node.type === 'gnd'
     const initialValues: any = {
       label: node.data?.label || '',


### PR DESCRIPTION
## Summary
- add a new HAPS (High Altitude Platform Station) node type
- show HAPS in the palette
- support HAPS nodes in the canvas and properties panel
- document HAPS in README

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_687db79f7f10832cbce2af5be1167d95