### PR TITLE
Add altitude range defaults

### DIFF
--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -29,6 +29,7 @@ import {
   SCALE,
   updateEdgesDistances,
 } from '../utils/geo'
+import { ALTITUDE_RANGES } from '../utils/altitudes'
 import { useCallback, useEffect, useState } from 'react'
 import toast from 'react-hot-toast'
 
@@ -100,7 +101,11 @@ export default function Canvas() {
       })
       const id = `${type}-${Date.now()}`
       const { lat, lon } = posToLatLon(position)
-      dispatch(addNode({ id, type, position, data: { label: id, lat, lon } }))
+      const data: any = { label: id, lat, lon }
+      if (ALTITUDE_RANGES[type]) {
+        data.altitude = ALTITUDE_RANGES[type].min
+      }
+      dispatch(addNode({ id, type, position, data }))
       dispatch(setAddingType(null))
       toast.success('Узел добавлен')
     },

--- a/src/components/PropertiesPanel.tsx
+++ b/src/components/PropertiesPanel.tsx
@@ -10,6 +10,7 @@ import {
   setElements,
 } from '../features/network/networkSlice'
 import { latLonToPos, updateEdgesDistances } from '../utils/geo'
+import { ALTITUDE_RANGES } from '../utils/altitudes'
 import toast from 'react-hot-toast'
 
 const typeNames: Record<string, string> = {
@@ -69,7 +70,9 @@ export default function PropertiesPanel() {
       lat: node.data?.lat ?? 0,
       lon: node.data?.lon ?? 0,
     }
-    if (isSatellite) initialValues.altitude = node.data?.altitude || ''
+    if (isSatellite)
+      initialValues.altitude =
+        node.data?.altitude ?? ALTITUDE_RANGES[node.type || '']?.min ?? ''
     if (isGround) initialValues.location = node.data?.location || ''
 
     const schemaShape: any = {
@@ -77,7 +80,17 @@ export default function PropertiesPanel() {
       lat: Yup.number().min(0).max(180).required(),
       lon: Yup.number().min(0).max(360).required(),
     }
-    if (isSatellite) schemaShape.altitude = Yup.number().required()
+    if (isSatellite) {
+      const range = ALTITUDE_RANGES[node.type || '']
+      if (range) {
+        schemaShape.altitude = Yup.number()
+          .min(range.min)
+          .max(range.max)
+          .required()
+      } else {
+        schemaShape.altitude = Yup.number().required()
+      }
+    }
     if (isGround) schemaShape.location = Yup.string().required()
 
     return (

--- a/src/utils/altitudes.ts
+++ b/src/utils/altitudes.ts
@@ -1,0 +1,11 @@
+export interface AltitudeRange {
+  min: number;
+  max: number;
+}
+
+export const ALTITUDE_RANGES: Record<string, AltitudeRange> = {
+  leo: { min: 150, max: 2000 },
+  meo: { min: 8000, max: 15000 },
+  geo: { min: 36000, max: 36000 },
+  haps: { min: 10, max: 50 },
+};


### PR DESCRIPTION
## Summary
- set default altitude values when dropping a new node
- validate satellite altitude ranges in properties panel
- define altitude ranges for each orbit type

## Testing
- `npx vitest --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_687dbc3427f0832c926e5252f4f3b2c3