### PR TITLE
Add altitude and cluster visualization

### DIFF
--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -9,9 +9,11 @@ import ReactFlow, {
   applyNodeChanges,
   applyEdgeChanges,
   useReactFlow,
+  useStore,
 } from 'reactflow'
-import type { NodeTypes } from 'reactflow'
+import type { NodeTypes, Node } from 'reactflow'
 import NetworkNode from './NetworkNode'
+import ClusterNode from './ClusterNode'
 import { useAppDispatch, useAppSelector } from '../hooks'
 import {
   addNode,
@@ -30,7 +32,7 @@ import {
   updateEdgesDistances,
 } from '../utils/geo'
 import { ALTITUDE_RANGES } from '../utils/altitudes'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useState, useMemo } from 'react'
 import toast from 'react-hot-toast'
 
 const nodeTypes: NodeTypes = {
@@ -39,13 +41,44 @@ const nodeTypes: NodeTypes = {
   geo: NetworkNode,
   gnd: NetworkNode,
   haps: NetworkNode,
+  cluster: ClusterNode,
 }
 
 export default function Canvas() {
   const dispatch = useAppDispatch()
   const { nodes, edges, addingType } = useAppSelector(state => state.network)
   const reactFlow = useReactFlow()
+  const transform = useStore(state => state.transform)
   const [linkSource, setLinkSource] = useState<string | null>(null)
+  const [clusterInfo, setClusterInfo] = useState<{ position: { x: number; y: number }; nodes: Node[] } | null>(null)
+
+  const displayNodes = useMemo(() => {
+    const groups: Record<string, Node[]> = {}
+    nodes.forEach(n => {
+      const key = `${n.data?.lat ?? 0}-${n.data?.lon ?? 0}`
+      if (!groups[key]) groups[key] = []
+      groups[key].push(n)
+    })
+    const result: Node[] = []
+    Object.entries(groups).forEach(([key, group]) => {
+      if (group.length === 1) {
+        result.push(group[0])
+      } else {
+        group.forEach(n =>
+          result.push({ ...n, style: { ...(n.style || {}), display: 'none' } })
+        )
+        result.push({
+          id: `cluster-${key}`,
+          type: 'cluster',
+          position: group[0].position,
+          data: { nodes: group, count: group.length },
+          draggable: false,
+          selectable: false,
+        })
+      }
+    })
+    return result
+  }, [nodes])
 
   const onConnect = useCallback(
     (params: Connection) => {
@@ -53,7 +86,14 @@ export default function Canvas() {
       const tgt = nodes.find(n => n.id === params.target)
       let distance = 0
       if (src?.data && tgt?.data) {
-        distance = distanceKm(src.data.lat, src.data.lon, tgt.data.lat, tgt.data.lon)
+        distance = distanceKm(
+          src.data.lat,
+          src.data.lon,
+          tgt.data.lat,
+          tgt.data.lon,
+          src.data.altitude || 0,
+          tgt.data.altitude || 0
+        )
       }
       dispatch(
         addEdge({
@@ -125,6 +165,14 @@ export default function Canvas() {
     }
   }, [addingType, linkSource, nodes, dispatch])
 
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setClusterInfo(null)
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [])
+
   return (
     <div
       className={`w-full h-full map-bg flex ${addingType ? 'cursor-crosshair' : ''}`}
@@ -133,7 +181,7 @@ export default function Canvas() {
     >
       <ReactFlow
         style={{ width: 360 * SCALE, height: 180 * SCALE }}
-        nodes={nodes}
+        nodes={displayNodes}
         edges={edges}
         nodeTypes={nodeTypes}
         onNodesChange={onNodesChange}
@@ -153,7 +201,14 @@ export default function Canvas() {
                 const tgt = nodes.find(n => n.id === node.id)
                 let distance = 0
                 if (src?.data && tgt?.data) {
-                  distance = distanceKm(src.data.lat, src.data.lon, tgt.data.lat, tgt.data.lon)
+                  distance = distanceKm(
+                    src.data.lat,
+                    src.data.lon,
+                    tgt.data.lat,
+                    tgt.data.lon,
+                    src.data.altitude || 0,
+                    tgt.data.altitude || 0
+                  )
                 }
                 const id = `e-${linkSource}-${node.id}-${Date.now()}`
                 dispatch(
@@ -173,6 +228,8 @@ export default function Canvas() {
               dispatch(setAddingType(null))
               toast.success('Связь создана')
             }
+          } else if (node.type === 'cluster') {
+            setClusterInfo({ position: node.position, nodes: node.data.nodes })
           } else {
             dispatch(select(node.id))
           }
@@ -195,6 +252,34 @@ export default function Canvas() {
         <Controls />
         <MiniMap />
       </ReactFlow>
+      {clusterInfo && (
+        <div
+          className="absolute inset-0 z-10"
+          onClick={() => setClusterInfo(null)}
+        >
+          <div
+            className="absolute bg-white border rounded shadow text-xs"
+            style={{
+              left: clusterInfo.position.x * transform[2] + transform[0],
+              top: clusterInfo.position.y * transform[2] + transform[1],
+            }}
+            onClick={e => e.stopPropagation()}
+          >
+            {clusterInfo.nodes.map(n => (
+              <div
+                key={n.id}
+                className="px-2 py-1 hover:bg-gray-100 cursor-pointer"
+                onClick={() => {
+                  dispatch(select(n.id))
+                  setClusterInfo(null)
+                }}
+              >
+                {n.data?.label || n.id}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/ClusterNode.tsx
+++ b/src/components/ClusterNode.tsx
@@ -1,0 +1,9 @@
+import { NodeProps } from 'reactflow'
+
+export default function ClusterNode({ data }: NodeProps<{ count: number }>) {
+  return (
+    <div className="bg-white border rounded-full w-6 h-6 flex items-center justify-center cursor-pointer text-xs">
+      {data.count}
+    </div>
+  )
+}

--- a/src/utils/geo.ts
+++ b/src/utils/geo.ts
@@ -30,21 +30,31 @@ export function distanceKm(
   lat1: number,
   lon1: number,
   lat2: number,
-  lon2: number
+  lon2: number,
+  alt1 = 0,
+  alt2 = 0
 ) {
   const lat1r = ((lat1 - 90) * Math.PI) / 180
   const lon1r = ((lon1 - 180) * Math.PI) / 180
   const lat2r = ((lat2 - 90) * Math.PI) / 180
   const lon2r = ((lon2 - 180) * Math.PI) / 180
 
-  const dLat = lat2r - lat1r
-  const dLon = lon2r - lon1r
+  const r1 = EARTH_RADIUS_KM + alt1
+  const r2 = EARTH_RADIUS_KM + alt2
 
-  const a =
-    Math.sin(dLat / 2) ** 2 +
-    Math.cos(lat1r) * Math.cos(lat2r) * Math.sin(dLon / 2) ** 2
-  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
-  return EARTH_RADIUS_KM * c
+  const x1 = r1 * Math.cos(lat1r) * Math.cos(lon1r)
+  const y1 = r1 * Math.cos(lat1r) * Math.sin(lon1r)
+  const z1 = r1 * Math.sin(lat1r)
+
+  const x2 = r2 * Math.cos(lat2r) * Math.cos(lon2r)
+  const y2 = r2 * Math.cos(lat2r) * Math.sin(lon2r)
+  const z2 = r2 * Math.sin(lat2r)
+
+  const dx = x2 - x1
+  const dy = y2 - y1
+  const dz = z2 - z1
+
+  return Math.sqrt(dx * dx + dy * dy + dz * dz)
 }
 
 import type { Node, Edge } from 'reactflow'
@@ -61,7 +71,9 @@ export function updateEdgesDistances(nodes: Node[], edges: Edge[]): Edge[] {
         src.data.lat,
         src.data.lon,
         tgt.data.lat,
-        tgt.data.lon
+        tgt.data.lon,
+        src.data.altitude || 0,
+        tgt.data.altitude || 0
       )
       return {
         ...e,


### PR DESCRIPTION
## Summary
- include altitude when computing distances
- recalc edge distances when altitude changes
- add a ClusterNode component for overlapping nodes
- group nodes with same coordinates and show pop-up list

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_687dc1c3fd78832c9203d4f75d5ab37d