### PR TITLE
Fix clustering for overlapping nodes

### DIFF
--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -28,6 +28,7 @@ import {
   distanceKm,
   SCALE,
   updateEdgesDistances,
+  coordKey,
 } from '../utils/geo'
 import { ALTITUDE_RANGES } from '../utils/altitudes'
 import { useCallback, useEffect, useState, useMemo } from 'react'
@@ -55,7 +56,7 @@ export default function Canvas() {
       const lat = (n.data as any)?.lat
       const lon = (n.data as any)?.lon
       if (lat == null || lon == null) continue
-      const key = `${lat}-${lon}`
+      const key = coordKey(lat, lon)
       if (!map[key]) map[key] = []
       map[key].push(n)
     }
@@ -110,7 +111,7 @@ export default function Canvas() {
           next.delete(key)
         } else if (!selectedId || !list.some(n => n.id === selectedId)) {
           const same = list.every(
-            n => `${(n.data as any)?.lat}-${(n.data as any)?.lon}` === key
+            n => coordKey((n.data as any)?.lat, (n.data as any)?.lon) === key
           )
           if (same) next.delete(key)
         }

--- a/src/index.css
+++ b/src/index.css
@@ -12,8 +12,8 @@ html, body, #root {
 }
 
 .map-bg {
-  background-image: \
-    repeating-linear-gradient(to right, #e0e0e0 1px, transparent 1px, transparent 50px),\
+  background-image:
+    repeating-linear-gradient(to right, #e0e0e0 1px, transparent 1px, transparent 50px),
     repeating-linear-gradient(to bottom, #e0e0e0 1px, transparent 1px, transparent 50px);
   background-size: 50px 50px;
 }

--- a/src/utils/geo.ts
+++ b/src/utils/geo.ts
@@ -20,6 +20,14 @@ export function posToLatLon(pos: { x: number; y: number }) {
   return { lat: lat + 90, lon: lon + 180 }
 }
 
+/**
+ * Returns a string key for grouping nodes by coordinates.
+ * Values are rounded to a fixed precision to avoid floating point issues.
+ */
+export function coordKey(lat: number, lon: number, precision = 6): string {
+  return `${lat.toFixed(precision)}-${lon.toFixed(precision)}`
+}
+
 export const EARTH_RADIUS_KM = 6371
 
 /**


### PR DESCRIPTION
## Summary
- ensure consistent grouping of nodes by rounding coordinates with `coordKey`
- add helper `coordKey` function
- fix CSS escaping in map grid background

## Testing
- `npm test` *(fails: No test files found)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687de55ec49c832c86ac75543fed6e38