### PR TITLE
Fix infinite render loop from cluster nodes

### DIFF
--- a/src/features/network/networkSlice.ts
+++ b/src/features/network/networkSlice.ts
@@ -4,10 +4,13 @@ import { NetworkState, RFNodeEx } from './types'
 
 export function groupNodes(nodes: RFNodeEx[]): RFNodeEx[] {
   const map = new Map<string, RFNodeEx[]>()
-  nodes.forEach(n => {
-    const key = `${n.position.x}|${n.position.y}`
-    map.set(key, [...(map.get(key) ?? []), n])
-  })
+  nodes
+    // ignore previously generated cluster nodes to avoid recursive grouping
+    .filter(n => n.type !== 'cluster')
+    .forEach(n => {
+      const key = `${n.position.x}|${n.position.y}`
+      map.set(key, [...(map.get(key) ?? []), n])
+    })
 
   const result: RFNodeEx[] = []
   for (const [key, group] of map) {


### PR DESCRIPTION
## Summary
- avoid grouping already created cluster nodes

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_687df4edc034832cb8ff49d8eacb6d55