### PR TITLE
Add altitude-aware distance calculations

### DIFF
--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -56,7 +56,14 @@ export default function Canvas() {
       const tgt = nodes.find(n => n.id === params.target)
       let distance = 0
       if (src?.data && tgt?.data) {
-        distance = distanceKm(src.data.lat, src.data.lon, tgt.data.lat, tgt.data.lon)
+        distance = distanceKm(
+          src.data.lat,
+          src.data.lon,
+          tgt.data.lat,
+          tgt.data.lon,
+          src.data.altitude || 0,
+          tgt.data.altitude || 0
+        )
       }
       dispatch(
         addEdge({
@@ -157,7 +164,14 @@ export default function Canvas() {
                 const tgt = nodes.find(n => n.id === node.id)
                 let distance = 0
                 if (src?.data && tgt?.data) {
-                  distance = distanceKm(src.data.lat, src.data.lon, tgt.data.lat, tgt.data.lon)
+                  distance = distanceKm(
+                    src.data.lat,
+                    src.data.lon,
+                    tgt.data.lat,
+                    tgt.data.lon,
+                    src.data.altitude || 0,
+                    tgt.data.altitude || 0
+                  )
                 }
                 const id = `e-${linkSource}-${node.id}-${Date.now()}`
                 dispatch(

--- a/src/utils/geo.ts
+++ b/src/utils/geo.ts
@@ -23,28 +23,35 @@ export function posToLatLon(pos: { x: number; y: number }) {
 export const EARTH_RADIUS_KM = 6371
 
 /**
- * Returns great-circle distance between two coordinates in kilometers.
- * Inputs are positive latitude `[0,180]` and longitude `[0,360]`.
+ * Returns straight-line distance between two points in kilometers.
+ * Latitude and longitude inputs are in positive ranges `[0,180]` and `[0,360]`.
+ * Altitudes are in kilometers above Earth's surface.
  */
 export function distanceKm(
   lat1: number,
   lon1: number,
   lat2: number,
-  lon2: number
+  lon2: number,
+  alt1 = 0,
+  alt2 = 0
 ) {
   const lat1r = ((lat1 - 90) * Math.PI) / 180
   const lon1r = ((lon1 - 180) * Math.PI) / 180
   const lat2r = ((lat2 - 90) * Math.PI) / 180
   const lon2r = ((lon2 - 180) * Math.PI) / 180
 
-  const dLat = lat2r - lat1r
-  const dLon = lon2r - lon1r
+  const r1 = EARTH_RADIUS_KM + alt1
+  const r2 = EARTH_RADIUS_KM + alt2
 
-  const a =
-    Math.sin(dLat / 2) ** 2 +
-    Math.cos(lat1r) * Math.cos(lat2r) * Math.sin(dLon / 2) ** 2
-  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
-  return EARTH_RADIUS_KM * c
+  const x1 = r1 * Math.cos(lat1r) * Math.cos(lon1r)
+  const y1 = r1 * Math.cos(lat1r) * Math.sin(lon1r)
+  const z1 = r1 * Math.sin(lat1r)
+
+  const x2 = r2 * Math.cos(lat2r) * Math.cos(lon2r)
+  const y2 = r2 * Math.cos(lat2r) * Math.sin(lon2r)
+  const z2 = r2 * Math.sin(lat2r)
+
+  return Math.sqrt((x1 - x2) ** 2 + (y1 - y2) ** 2 + (z1 - z2) ** 2)
 }
 
 import type { Node, Edge } from 'reactflow'
@@ -61,7 +68,9 @@ export function updateEdgesDistances(nodes: Node[], edges: Edge[]): Edge[] {
         src.data.lat,
         src.data.lon,
         tgt.data.lat,
-        tgt.data.lon
+        tgt.data.lon,
+        src.data.altitude || 0,
+        tgt.data.altitude || 0
       )
       return {
         ...e,


### PR DESCRIPTION
## Summary
- compute 3D distance between nodes using altitude when provided
- display new distance on edges when connecting or updating nodes

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68820f581f20832cbb1f4c993b365ac6