### PR TITLE
feat: add mock API server

### DIFF
--- a/mock-api.js
+++ b/mock-api.js
@@ -1,0 +1,18 @@
+import { createServer } from 'node:http';
+
+const PORT = process.env.PORT || 3001;
+
+const server = createServer((req, res) => {
+  if (req.method === 'GET' && req.url === '/api/ping') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ message: 'pong' }));
+    return;
+  }
+
+  res.writeHead(404, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({ error: 'Not found' }));
+});
+
+server.listen(PORT, () => {
+  console.log(`Mock API server listening on http://localhost:${PORT}`);
+});

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest"
+    "test": "vitest",
+    "mock-api": "node mock-api.js"
   },
   "dependencies": {
     "@heroicons/react": "^2.1.3",


### PR DESCRIPTION
## Summary
- add mock API server for frontend testing
- add npm script `mock-api` to start the server

## Testing
- `npm test` (fails: No test files found)
- `node mock-api.js` & `curl http://localhost:3001/api/ping`

------
https://chatgpt.com/codex/tasks/task_e_68918d8dd2d8832cb1cdae2668c6a236