### PR TITLE
Add FastAPI backend for saving topologies to PostgreSQL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,7 @@ out/
 # package-lock.json
 # yarn.lock
 # pnpm-lock.yaml
+
+# Python
+__pycache__/
+*.py[cod]

--- a/README.md
+++ b/README.md
@@ -8,3 +8,28 @@ This prototype uses **React 18**, **TypeScript 5** and **Vite**. It provides a s
 - State management via Redux Toolkit
 
 All data is stored in the local Redux slice `network`.
+
+## Backend API
+
+The `backend` directory contains a minimal **FastAPI** application that
+persists network topologies in a PostgreSQL 17 database. Each topology record
+includes a user supplied name, the JSON representation of the topology and the
+timestamp when it was created.
+
+### Running
+
+1. Install dependencies:
+
+   ```bash
+   pip install -r backend/requirements.txt
+   ```
+
+2. Start the API (ensure the `DATABASE_URL` environment variable points to your
+   PostgreSQL instance):
+
+   ```bash
+   uvicorn backend.main:app --reload
+   ```
+
+3. Use `POST /topologies` to save a topology and `GET /topologies` to list all
+   saved entries.

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,0 +1,12 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+DATABASE_URL = os.environ.get(
+    "DATABASE_URL",
+    "postgresql+psycopg2://postgres:postgres@localhost:5432/postgres",
+)
+
+engine = create_engine(DATABASE_URL)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,31 @@
+from fastapi import Depends, FastAPI
+from sqlalchemy.orm import Session
+
+from . import models, schemas
+from .database import SessionLocal, engine
+
+models.Base.metadata.create_all(bind=engine)
+
+app = FastAPI()
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@app.post("/topologies", response_model=schemas.Topology)
+def create_topology(topology: schemas.TopologyCreate, db: Session = Depends(get_db)):
+    db_topology = models.Topology(name=topology.name, data=topology.data)
+    db.add(db_topology)
+    db.commit()
+    db.refresh(db_topology)
+    return db_topology
+
+
+@app.get("/topologies", response_model=list[schemas.Topology])
+def list_topologies(db: Session = Depends(get_db)):
+    return db.query(models.Topology).order_by(models.Topology.created_at.desc()).all()

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,14 @@
+from datetime import datetime
+from sqlalchemy import Column, DateTime, Integer, String
+from sqlalchemy.dialects.postgresql import JSONB
+
+from .database import Base
+
+
+class Topology(Base):
+    __tablename__ = "topologies"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)
+    data = Column(JSONB, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn[standard]
+sqlalchemy
+psycopg2-binary
+pydantic

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,0 +1,19 @@
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class TopologyCreate(BaseModel):
+    name: str
+    data: Any
+
+
+class Topology(BaseModel):
+    id: int
+    name: str
+    data: Any
+    created_at: datetime
+
+    class Config:
+        orm_mode = True


### PR DESCRIPTION
## Summary
- add FastAPI backend with SQLAlchemy models for storing topology JSON in PostgreSQL
- document backend usage and how to run it
- ignore Python cache files

## Testing
- `npm test -- --passWithNoTests`
- `python -m py_compile backend/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5221a27a883298c137f8e0f08f49a