### PR TITLE
Add PostgreSQL service and configure backend connection

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-DATABASE_URL=postgresql+psycopg2://postgres:eyufyuf@localhost:5432/network_simulation_db
+DATABASE_URL=postgresql+psycopg2://postgres:eyufyuf@db:5432/network_simulation_db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,21 @@
 version: "3.9"
 services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: eyufyuf
+      POSTGRES_DB: network_simulation_db
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
   backend:
     build: ./backend
     environment:
       - DATABASE_URL=${DATABASE_URL}
+    depends_on:
+      - db
     ports:
       - "8000:8000"
   frontend:
@@ -12,3 +24,6 @@ services:
       - "3000:3000"
     depends_on:
       - backend
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
## Summary
- add postgres database container to docker-compose with persistent volume
- point backend to the postgres service via DATABASE_URL

## Testing
- `python -m py_compile backend/database.py backend/main.py`
- `docker compose version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7954a85548333954a147070e3695c