### PR TITLE
feat: add topology selection modal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+frontend/node_modules/

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -28,4 +28,4 @@ def create_topology(topology: schemas.TopologyCreate, db: Session = Depends(get_
 
 @app.get("/topologies", response_model=list[schemas.Topology])
 def list_topologies(db: Session = Depends(get_db)):
-    return db.query(models.Topology).order_by(models.Topology.created_at.desc()).all()
+    return db.query(models.Topology).order_by(models.Topology.updated_at.desc()).all()

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -12,3 +12,6 @@ class Topology(Base):
     name = Column(String, nullable=False)
     data = Column(JSONB, nullable=False)
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = Column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+    )

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -14,6 +14,7 @@ class Topology(BaseModel):
     name: str
     data: Any
     created_at: datetime
+    updated_at: datetime
 
     class Config:
         orm_mode = True

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,9 +4,12 @@ import Canvas from './components/Canvas'
 import PropertiesPanel from './components/PropertiesPanel'
 import { useAppSelector } from './hooks'
 import { Toaster } from 'react-hot-toast'
+import { useState } from 'react'
+import TopologyModal from './components/TopologyModal'
 
 export default function App() {
-  const selectedId = useAppSelector(state => state.network.selectedId)
+  const { selectedId, nodes, edges } = useAppSelector(state => state.network)
+  const [showModal, setShowModal] = useState(nodes.length === 0 && edges.length === 0)
 
   return (
     <>
@@ -24,6 +27,7 @@ export default function App() {
         </div>
         <Toaster position="top-right" />
       </div>
+      {showModal && <TopologyModal onClose={() => setShowModal(false)} />}
     </>
   )
 }

--- a/frontend/src/components/TopologyModal.tsx
+++ b/frontend/src/components/TopologyModal.tsx
@@ -1,0 +1,84 @@
+import { useEffect, useState } from 'react'
+import { useAppDispatch } from '../hooks'
+import { setElements } from '../features/network/networkSlice'
+import type { Node, Edge } from 'reactflow'
+
+interface Topology {
+  id: number
+  name: string
+  data: { nodes: Node[]; edges: Edge[] }
+  updated_at: string
+}
+
+interface Props {
+  onClose: () => void
+}
+
+export default function TopologyModal({ onClose }: Props) {
+  const dispatch = useAppDispatch()
+  const [topologies, setTopologies] = useState<Topology[]>([])
+  const [name, setName] = useState('')
+
+  useEffect(() => {
+    fetch('http://localhost:8000/topologies')
+      .then(res => res.json())
+      .then(data => setTopologies(data))
+      .catch(() => setTopologies([]))
+  }, [])
+
+  const handleSelect = (topology: Topology) => {
+    dispatch(setElements(topology.data))
+    onClose()
+  }
+
+  const handleCreate = async () => {
+    if (!name.trim()) return
+    const res = await fetch('http://localhost:8000/topologies', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, data: { nodes: [], edges: [] } }),
+    })
+    if (res.ok) {
+      onClose()
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-30">
+      <div className="bg-white p-4 rounded w-96 max-h-[80vh] overflow-y-auto">
+        <h2 className="text-lg font-bold mb-4">Выберите топологию</h2>
+        <ul className="mb-4 space-y-2">
+          {topologies.map(t => (
+            <li key={t.id} className="flex justify-between items-center">
+              <button
+                className="text-left text-blue-600 hover:underline flex-1"
+                onClick={() => handleSelect(t)}
+              >
+                {t.name}
+              </button>
+              <span className="text-sm text-gray-500 ml-2">
+                {new Date(t.updated_at).toLocaleString()}
+              </span>
+            </li>
+          ))}
+        </ul>
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={name}
+            onChange={e => setName(e.target.value)}
+            placeholder="Название новой топологии"
+            className="border rounded px-2 py-1 flex-1"
+          />
+          <button
+            onClick={handleCreate}
+            className="bg-blue-500 text-white px-3 py-1 rounded"
+          >
+            Создать
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- show modal on start to select or create topology
- track topology update time in backend models

## Testing
- `npm test -- --passWithNoTests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c79d1d96c88333aada4dbe7fe70502