### PR TITLE
Add nginx reverse proxy for unified domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ Ensure a PostgreSQL database is available and reachable via the `DATABASE_URL` e
 docker-compose up --build
 ```
 
-The frontend will be available at http://localhost:3000 and the backend at http://localhost:8000.
+The application is served through an Nginx reverse proxy at [http://localhost](http://localhost). All API requests are routed through `/api`, so the backend is reachable at [http://localhost/api](http://localhost/api) while the frontend is available at the root path.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,13 +16,23 @@ services:
       - DATABASE_URL=${DATABASE_URL}
     depends_on:
       - db
-    ports:
-      - "8000:8000"
+    expose:
+      - "8000"
   frontend:
     build: ./frontend
-    ports:
-      - "3000:3000"
     depends_on:
+      - backend
+    expose:
+      - "3000"
+
+  nginx:
+    image: nginx:alpine
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      - frontend
       - backend
 
 volumes:

--- a/frontend/src/components/TopologyModal.tsx
+++ b/frontend/src/components/TopologyModal.tsx
@@ -20,7 +20,7 @@ export default function TopologyModal({ onClose }: Props) {
   const [name, setName] = useState('')
 
   useEffect(() => {
-    fetch('http://localhost:8000/topologies')
+    fetch('/api/topologies')
       .then(res => res.json())
       .then(data => setTopologies(data))
       .catch(() => setTopologies([]))
@@ -33,7 +33,7 @@ export default function TopologyModal({ onClose }: Props) {
 
   const handleCreate = async () => {
     if (!name.trim()) return
-    const res = await fetch('http://localhost:8000/topologies', {
+    const res = await fetch('/api/topologies', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name, data: { nodes: [], edges: [] } }),

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,15 @@
+server {
+    listen 80;
+
+    location /api/ {
+        proxy_pass http://backend:8000/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    location / {
+        proxy_pass http://frontend:3000/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}


### PR DESCRIPTION
## Summary
- add nginx container to serve frontend and backend on one domain
- route frontend and API traffic through nginx and update URLs
- document new unified access instructions

## Testing
- `pytest`
- `npm test` *(fails: npm: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c79f0d651883339aa4ad9c7d1dd2ad