### PR TITLE
feat: add topology websocket

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,4 @@
-from fastapi import Depends, FastAPI
+from fastapi import Depends, FastAPI, WebSocket, WebSocketDisconnect
 from sqlalchemy.orm import Session
 
 from . import models, schemas
@@ -29,3 +29,29 @@ def create_topology(topology: schemas.TopologyCreate, db: Session = Depends(get_
 @app.get("/topologies", response_model=list[schemas.Topology])
 def list_topologies(db: Session = Depends(get_db)):
     return db.query(models.Topology).order_by(models.Topology.updated_at.desc()).all()
+
+
+@app.websocket("/ws/topology")
+async def topology_updates(websocket: WebSocket, db: Session = Depends(get_db)):
+    await websocket.accept()
+    try:
+        while True:
+            message = await websocket.receive_json()
+            topology_id = message.get("id")
+            data = message.get("data")
+            if topology_id is None or data is None:
+                await websocket.send_json({"error": "id and data required"})
+                continue
+            topology = db.query(models.Topology).filter(models.Topology.id == topology_id).first()
+            if topology is None:
+                await websocket.send_json({"error": "topology not found"})
+                continue
+            topology.data = data
+            db.add(topology)
+            db.commit()
+            db.refresh(topology)
+            await websocket.send_json(
+                {"status": "updated", "topology": schemas.Topology.from_orm(topology).dict()}
+            )
+    except WebSocketDisconnect:
+        pass

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -7,6 +7,15 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
     }
 
+    location /ws/ {
+        proxy_pass http://backend:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
     location / {
         proxy_pass http://frontend:3000/;
         proxy_set_header Host $host;


### PR DESCRIPTION
## Summary
- add websocket endpoint for updating topology records
- configure nginx to proxy websocket connections

## Testing
- `python -m py_compile backend/app/main.py`
- `nginx -t -c nginx/nginx.conf` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7a28114808333b611c7c09f50feab