### PR TITLE
feat: replace websockets with manual save

### DIFF
--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -1,9 +1,11 @@
 import PaletteButton from './PaletteButton'
-import { TrashIcon, ArrowDownTrayIcon } from '@heroicons/react/24/solid'
+import { TrashIcon, ArrowDownTrayIcon, ArrowUpTrayIcon } from '@heroicons/react/24/solid'
 import { useAppSelector } from '../hooks'
+import { useCallback, useEffect } from 'react'
+import toast from 'react-hot-toast'
 
 export default function TopBar() {
-  const { nodes, edges } = useAppSelector(state => state.network)
+  const { nodes, edges, topologyId } = useAppSelector(state => state.network)
 
   const handleDownload = () => {
     const json = JSON.stringify({ nodes, edges }, null, 2)
@@ -16,16 +18,51 @@ export default function TopBar() {
     URL.revokeObjectURL(url)
   }
 
+  const handleSave = useCallback(async () => {
+    if (topologyId === null) return
+    const res = await fetch(`/api/topologies/${topologyId}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ data: { nodes, edges } }),
+    })
+    if (res.ok) {
+      toast.success('Сохранено')
+    } else {
+      toast.error('Ошибка сохранения')
+    }
+  }, [topologyId, nodes, edges])
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === 's') {
+        e.preventDefault()
+        handleSave()
+      }
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [handleSave])
+
   return (
     <div className="fixed top-0 left-0 w-full h-12 bg-white border-b flex items-center justify-between px-2 z-20">
-      <button
-        type="button"
-        onClick={handleDownload}
-        title="Скачать топологию"
-        className="flex items-center justify-center w-10 h-10 rounded bg-gray-100 hover:bg-gray-200"
-      >
-        <ArrowDownTrayIcon className="w-5 h-5" />
-      </button>
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={handleSave}
+          title="Сохранить топологию"
+          className="flex items-center justify-center w-10 h-10 rounded bg-gray-100 hover:bg-gray-200"
+        >
+          <ArrowUpTrayIcon className="w-5 h-5" />
+        </button>
+        <button
+          type="button"
+          onClick={handleDownload}
+          title="Скачать топологию"
+          className="flex items-center justify-center w-10 h-10 rounded bg-gray-100 hover:bg-gray-200"
+        >
+          <ArrowDownTrayIcon className="w-5 h-5" />
+        </button>
+      </div>
       <PaletteButton icon={TrashIcon} label="Удалить" type="delete" />
     </div>
   )

--- a/frontend/src/components/TopologyModal.tsx
+++ b/frontend/src/components/TopologyModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useAppDispatch } from '../hooks'
-import { setElements } from '../features/network/networkSlice'
+import { setTopology } from '../features/network/networkSlice'
 import type { Node, Edge } from 'reactflow'
 
 interface Topology {
@@ -27,7 +27,9 @@ export default function TopologyModal({ onClose }: Props) {
   }, [])
 
   const handleSelect = (topology: Topology) => {
-    dispatch(setElements(topology.data))
+    dispatch(
+      setTopology({ id: topology.id, nodes: topology.data.nodes, edges: topology.data.edges })
+    )
     onClose()
   }
 
@@ -39,6 +41,10 @@ export default function TopologyModal({ onClose }: Props) {
       body: JSON.stringify({ name, data: { nodes: [], edges: [] } }),
     })
     if (res.ok) {
+      const topology: Topology = await res.json()
+      dispatch(
+        setTopology({ id: topology.id, nodes: topology.data.nodes, edges: topology.data.edges })
+      )
       onClose()
     }
   }

--- a/frontend/src/features/network/networkSlice.ts
+++ b/frontend/src/features/network/networkSlice.ts
@@ -5,6 +5,7 @@ import { NetworkState } from './types'
 const initialState: NetworkState = {
   nodes: [],
   edges: [],
+  topologyId: null,
   selectedId: null,
   addingType: null,
   nearby: null,
@@ -15,6 +16,14 @@ const networkSlice = createSlice({
   initialState,
   reducers: {
     setElements(state, action: PayloadAction<{ nodes: Node[]; edges: Edge[] }>) {
+      state.nodes = action.payload.nodes
+      state.edges = action.payload.edges
+    },
+    setTopology(
+      state,
+      action: PayloadAction<{ id: number; nodes: Node[]; edges: Edge[] }>
+    ) {
+      state.topologyId = action.payload.id
       state.nodes = action.payload.nodes
       state.edges = action.payload.edges
     },
@@ -62,6 +71,7 @@ const networkSlice = createSlice({
 
 export const {
   setElements,
+  setTopology,
   addNode,
   addEdge,
   updateNode,

--- a/frontend/src/features/network/types.ts
+++ b/frontend/src/features/network/types.ts
@@ -3,6 +3,7 @@ import { Node, Edge } from 'reactflow'
 export interface NetworkState {
   nodes: Node[]
   edges: Edge[]
+  topologyId: number | null
   selectedId: string | null
   addingType: string | null
   nearby: { ids: string[]; x: number; y: number } | null

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -7,15 +7,6 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
     }
 
-    location /ws/ {
-        proxy_pass http://backend:8000;
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-    }
-
     location / {
         proxy_pass http://frontend:3000/;
         proxy_set_header Host $host;


### PR DESCRIPTION
## Summary
- remove websocket endpoint and use REST to update topology
- track active topology in store and show a manual save button
- drop websocket proxy from nginx config

## Testing
- `pytest`
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7a53d1600833393d0a45faaeb3c06