### PR TITLE
Allow updating topology without name

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -33,14 +33,17 @@ def list_topologies(db: Session = Depends(get_db)):
 
 @app.put("/topologies/{topology_id}", response_model=schemas.Topology)
 def update_topology(
-    topology_id: int, topology: schemas.TopologyCreate, db: Session = Depends(get_db)
+    topology_id: int, topology: schemas.TopologyUpdate, db: Session = Depends(get_db)
 ):
     db_topology = (
         db.query(models.Topology).filter(models.Topology.id == topology_id).first()
     )
     if db_topology is None:
         raise HTTPException(status_code=404, detail="topology not found")
+
     db_topology.data = topology.data
+    if topology.name is not None:
+        db_topology.name = topology.name
     db.add(db_topology)
     db.commit()
     db.refresh(db_topology)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -9,6 +9,18 @@ class TopologyCreate(BaseModel):
     data: Any
 
 
+class TopologyUpdate(BaseModel):
+    """Schema for updating an existing topology.
+
+    Only the `data` field is required. The `name` field is optional so that
+    clients can update the topology's structure without needing to resend the
+    name, which previously caused validation errors when omitted.
+    """
+
+    data: Any
+    name: str | None = None
+
+
 class Topology(BaseModel):
     id: int
     name: str


### PR DESCRIPTION
## Summary
- add `TopologyUpdate` schema with optional name
- allow updating topology data without resending the name

## Testing
- `pytest`
- `python -m py_compile backend/app/main.py backend/app/schemas.py`


------
https://chatgpt.com/codex/tasks/task_e_68c7b75219d0833381a36755089fe0e2