### PR TITLE
feat(domain): enforce port policies and add topology IO

### DIFF
--- a/frontend/src/domain/index.ts
+++ b/frontend/src/domain/index.ts
@@ -1,3 +1,4 @@
 export * from './types'
 export * from './rules'
 export * from './operations'
+export * from './io'

--- a/frontend/src/domain/io.ts
+++ b/frontend/src/domain/io.ts
@@ -1,0 +1,9 @@
+import { Topology } from './types'
+
+export const exportTopology = (topology: Topology): string =>
+  JSON.stringify(topology)
+
+export const importTopology = (json: string): Topology => {
+  const parsed = JSON.parse(json)
+  return parsed as Topology
+}


### PR DESCRIPTION
## Summary
- enforce strict port usage with defaults and self-loop checks
- add JSON import/export helpers for topology state
- test port policies, self-loop prevention, and import/export round-trip

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7d230e07c833383eaf6f08c826d09