### PR TITLE
Add interface UI and logic for node connections

### DIFF
--- a/frontend/src/components/InterfacesPopup.tsx
+++ b/frontend/src/components/InterfacesPopup.tsx
@@ -1,0 +1,116 @@
+import { useEffect, useMemo, useRef } from 'react'
+import { useAppDispatch, useAppSelector } from '../hooks'
+import {
+  closeInterfaces,
+  closeNearby,
+  select,
+} from '../features/network/networkSlice'
+import {
+  createInterfaceSelectionId,
+  directionLabels,
+  NodeInterface,
+  parseInterfaceSelectionId,
+} from '../utils/interfaces'
+
+export default function InterfacesPopup() {
+  const dispatch = useAppDispatch()
+  const { interfacePopup, nodes, selectedId } = useAppSelector(
+    state => state.network
+  )
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const handle = (event: MouseEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        dispatch(closeInterfaces())
+      }
+    }
+    document.addEventListener('mousedown', handle)
+    return () => document.removeEventListener('mousedown', handle)
+  }, [dispatch])
+
+  useEffect(() => {
+    if (!interfacePopup) return
+    const exists = nodes.some(node => node.id === interfacePopup.nodeId)
+    if (!exists) dispatch(closeInterfaces())
+  }, [dispatch, interfacePopup, nodes])
+
+  const selection = useMemo(
+    () => parseInterfaceSelectionId(selectedId),
+    [selectedId]
+  )
+
+  if (!interfacePopup) return null
+
+  const node = nodes.find(n => n.id === interfacePopup.nodeId)
+  if (!node) return null
+
+  const interfaces = Array.isArray(node.data?.interfaces)
+    ? (node.data!.interfaces as NodeInterface[])
+    : []
+
+  const width = 280
+  const leftBoundary = 80
+  const rightBoundary = window.innerWidth - (selectedId ? 320 : 0)
+  let left = interfacePopup.x
+  let top = interfacePopup.y
+  if (left + width > rightBoundary) left = rightBoundary - width - 10
+  if (left < leftBoundary) left = leftBoundary + 10
+  if (top < 60) top = 60
+
+  const nodeLabel = node.data?.label ? String(node.data.label) : node.id
+
+  return (
+    <div
+      ref={ref}
+      style={{ position: 'absolute', left, top, width }}
+      className="bg-white border rounded shadow z-50 text-sm"
+      onClick={event => event.stopPropagation()}
+    >
+      <div className="px-3 py-2 border-b font-semibold">
+        Интерфейсы узла {nodeLabel}
+      </div>
+      <div className="max-h-60 overflow-y-auto divide-y">
+        {interfaces.length === 0 && (
+          <div className="px-3 py-2 text-gray-500">Интерфейсы отсутствуют</div>
+        )}
+        {interfaces.map(iface => {
+          const active =
+            selection &&
+            selection.nodeId === node.id &&
+            selection.interfaceId === iface.id
+          return (
+            <button
+              key={iface.id}
+              type="button"
+              onClick={() => {
+                dispatch(
+                  select(createInterfaceSelectionId(node.id, iface.id))
+                )
+                dispatch(closeNearby())
+                dispatch(closeInterfaces())
+              }}
+              className={`block w-full text-left px-3 py-2 hover:bg-gray-100 ${
+                active ? 'bg-blue-50' : ''
+              }`}
+            >
+              <div className="font-medium">{iface.name}</div>
+              <div className="text-xs text-gray-500">
+                {directionLabels[iface.direction]} • {iface.connectedNodeLabel}
+              </div>
+            </button>
+          )
+        })}
+      </div>
+      <div className="border-t flex justify-end">
+        <button
+          type="button"
+          className="px-3 py-1 text-sm"
+          onClick={() => dispatch(closeInterfaces())}
+        >
+          Закрыть
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/NodeContextMenu.tsx
+++ b/frontend/src/components/NodeContextMenu.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useRef } from 'react'
+import { useAppDispatch, useAppSelector } from '../hooks'
+import {
+  closeNodeMenu,
+  openInterfaces,
+} from '../features/network/networkSlice'
+
+export default function NodeContextMenu() {
+  const dispatch = useAppDispatch()
+  const { contextMenu, selectedId } = useAppSelector(state => state.network)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const handle = (event: MouseEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        dispatch(closeNodeMenu())
+      }
+    }
+    document.addEventListener('mousedown', handle)
+    return () => document.removeEventListener('mousedown', handle)
+  }, [dispatch])
+
+  if (!contextMenu) return null
+
+  const width = 160
+  const leftBoundary = 80
+  const rightBoundary = window.innerWidth - (selectedId ? 320 : 0)
+  let left = contextMenu.x
+  let top = contextMenu.y
+  if (left + width > rightBoundary) left = rightBoundary - width - 10
+  if (left < leftBoundary) left = leftBoundary + 10
+
+  return (
+    <div
+      ref={ref}
+      style={{ position: 'absolute', left, top, width }}
+      className="bg-white border rounded shadow z-50 text-sm"
+      onClick={event => event.stopPropagation()}
+    >
+      <button
+        type="button"
+        className="block w-full text-left px-3 py-2 hover:bg-gray-100"
+        onClick={() => {
+          dispatch(openInterfaces({ nodeId: contextMenu.nodeId, x: left, y: top }))
+          dispatch(closeNodeMenu())
+        }}
+      >
+        Интерфейсы
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/features/network/networkSlice.ts
+++ b/frontend/src/features/network/networkSlice.ts
@@ -1,5 +1,11 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
-import { Node, Edge } from 'reactflow'
+import type { Node, Edge } from 'reactflow'
+import {
+  ensureAllEdgeInterfaces,
+  parseInterfaceSelectionId,
+  removeInterfacesByEdgeIds,
+} from '../../utils/interfaces'
+import type { NodeData, NodeInterface } from '../../utils/interfaces'
 import { NetworkState } from './types'
 
 const initialState: NetworkState = {
@@ -9,31 +15,53 @@ const initialState: NetworkState = {
   selectedId: null,
   addingType: null,
   nearby: null,
+  contextMenu: null,
+  interfacePopup: null,
 }
 
 const networkSlice = createSlice({
   name: 'network',
   initialState,
   reducers: {
-    setElements(state, action: PayloadAction<{ nodes: Node[]; edges: Edge[] }>) {
+    setElements(
+      state,
+      action: PayloadAction<{ nodes: Node<NodeData>[]; edges: Edge[] }>
+    ) {
       state.nodes = action.payload.nodes
       state.edges = action.payload.edges
     },
     setTopology(
       state,
-      action: PayloadAction<{ id: number; nodes: Node[]; edges: Edge[] }>
+      action: PayloadAction<{
+        id: number
+        nodes: Node<NodeData>[]
+        edges: Edge[]
+      }>
     ) {
       state.topologyId = action.payload.id
-      state.nodes = action.payload.nodes
+      const normalizedNodes = action.payload.nodes.map(node => {
+        const data = { ...(node.data ?? {}) }
+        if (Array.isArray(data.interfaces)) {
+          data.interfaces = (data.interfaces as NodeInterface[]).map(iface => ({
+            ...iface,
+          }))
+        }
+        return { ...node, data }
+      })
+      state.nodes = ensureAllEdgeInterfaces(normalizedNodes, action.payload.edges)
       state.edges = action.payload.edges
+      state.selectedId = null
+      state.nearby = null
+      state.contextMenu = null
+      state.interfacePopup = null
     },
-    addNode(state, action: PayloadAction<Node>) {
+    addNode(state, action: PayloadAction<Node<NodeData>>) {
       state.nodes.push(action.payload)
     },
     addEdge(state, action: PayloadAction<Edge>) {
       state.edges.push(action.payload)
     },
-    updateNode(state, action: PayloadAction<Node>) {
+    updateNode(state, action: PayloadAction<Node<NodeData>>) {
       const idx = state.nodes.findIndex(n => n.id === action.payload.id)
       if (idx !== -1) state.nodes[idx] = action.payload
     },
@@ -42,19 +70,67 @@ const networkSlice = createSlice({
       if (idx !== -1) state.edges[idx] = action.payload
     },
     removeElement(state, action: PayloadAction<string>) {
-      state.nodes = state.nodes.filter(n => n.id !== action.payload)
-      state.edges = state.edges.filter(e => e.id !== action.payload && e.source !== action.payload && e.target !== action.payload)
-      if (state.nearby && state.nearby.ids.includes(action.payload)) {
+      const id = action.payload
+      state.contextMenu = null
+      state.interfacePopup = null
+
+      const selection = parseInterfaceSelectionId(state.selectedId)
+      let removedEdgeIds: string[] = []
+
+      const nodeIndex = state.nodes.findIndex(n => n.id === id)
+      if (nodeIndex !== -1) {
+        removedEdgeIds = state.edges
+          .filter(e => e.source === id || e.target === id)
+          .map(e => e.id)
+        state.nodes = state.nodes.filter(n => n.id !== id)
+        state.edges = state.edges.filter(
+          e => e.id !== id && e.source !== id && e.target !== id
+        )
+      } else {
+        const edgeIndex = state.edges.findIndex(e => e.id === id)
+        if (edgeIndex !== -1) {
+          removedEdgeIds = [state.edges[edgeIndex].id]
+          state.edges.splice(edgeIndex, 1)
+        }
+      }
+
+      if (removedEdgeIds.length > 0) {
+        state.nodes = state.nodes.map(node =>
+          removeInterfacesByEdgeIds(node, removedEdgeIds)
+        )
+      }
+
+      if (state.nearby && state.nearby.ids.includes(id)) {
         state.nearby = null
+      }
+
+      if (selection) {
+        const exists = state.nodes.some(node => {
+          if (node.id !== selection.nodeId) return false
+          if (!node.data || !Array.isArray(node.data.interfaces)) return false
+          return (node.data.interfaces as NodeInterface[]).some(
+            iface => iface.id === selection.interfaceId
+          )
+        })
+        if (!exists) state.selectedId = null
+      } else if (
+        state.selectedId === id ||
+        (state.selectedId && removedEdgeIds.includes(state.selectedId))
+      ) {
+        state.selectedId = null
       }
     },
     select(state, action: PayloadAction<string | null>) {
       state.selectedId = action.payload
+      state.contextMenu = null
+      state.interfacePopup = null
     },
     setAddingType(state, action: PayloadAction<string | null>) {
       state.addingType = action.payload
       if (action.payload !== null) {
         state.nearby = null
+        state.contextMenu = null
+        state.interfacePopup = null
       }
     },
     openNearby(
@@ -62,9 +138,32 @@ const networkSlice = createSlice({
       action: PayloadAction<{ ids: string[]; x: number; y: number }>
     ) {
       state.nearby = action.payload
+      state.contextMenu = null
+      state.interfacePopup = null
     },
     closeNearby(state) {
       state.nearby = null
+    },
+    openNodeMenu(
+      state,
+      action: PayloadAction<{ nodeId: string; x: number; y: number }>
+    ) {
+      state.contextMenu = action.payload
+      state.nearby = null
+      state.interfacePopup = null
+    },
+    closeNodeMenu(state) {
+      state.contextMenu = null
+    },
+    openInterfaces(
+      state,
+      action: PayloadAction<{ nodeId: string; x: number; y: number }>
+    ) {
+      state.interfacePopup = action.payload
+      state.contextMenu = null
+    },
+    closeInterfaces(state) {
+      state.interfacePopup = null
     },
   },
 })
@@ -81,5 +180,9 @@ export const {
   setAddingType,
   openNearby,
   closeNearby,
+  openNodeMenu,
+  closeNodeMenu,
+  openInterfaces,
+  closeInterfaces,
 } = networkSlice.actions
 export default networkSlice.reducer

--- a/frontend/src/features/network/types.ts
+++ b/frontend/src/features/network/types.ts
@@ -1,10 +1,13 @@
-import { Node, Edge } from 'reactflow'
+import type { Node, Edge } from 'reactflow'
+import type { NodeData } from '../../utils/interfaces'
 
 export interface NetworkState {
-  nodes: Node[]
+  nodes: Node<NodeData>[]
   edges: Edge[]
   topologyId: number | null
   selectedId: string | null
   addingType: string | null
   nearby: { ids: string[]; x: number; y: number } | null
+  contextMenu: { nodeId: string; x: number; y: number } | null
+  interfacePopup: { nodeId: string; x: number; y: number } | null
 }

--- a/frontend/src/utils/interfaces.ts
+++ b/frontend/src/utils/interfaces.ts
@@ -1,0 +1,186 @@
+import type { Edge, Node } from 'reactflow'
+
+export type InterfaceDirection = 'in' | 'out'
+
+export interface NodeInterface {
+  id: string
+  name: string
+  direction: InterfaceDirection
+  edgeId: string
+  connectedNodeId: string
+  connectedNodeLabel: string
+  description: string
+}
+
+export interface NodeData {
+  label?: string
+  lat?: number
+  lon?: number
+  altitude?: number
+  location?: string
+  interfaces?: NodeInterface[]
+  [key: string]: unknown
+}
+
+export interface InterfaceSelection {
+  nodeId: string
+  interfaceId: string
+}
+
+const INTERFACE_SELECTION_PREFIX = 'iface'
+
+export const directionLabels: Record<InterfaceDirection, string> = {
+  in: 'Входящий',
+  out: 'Исходящий',
+}
+
+export const createInterfaceId = (): string =>
+  `${INTERFACE_SELECTION_PREFIX}-${Math.random().toString(36).slice(2, 10)}`
+
+export const createInterfaceSelectionId = (
+  nodeId: string,
+  interfaceId: string
+): string => `${INTERFACE_SELECTION_PREFIX}:${nodeId}:${interfaceId}`
+
+export const parseInterfaceSelectionId = (
+  value: string | null | undefined
+): InterfaceSelection | null => {
+  if (!value) return null
+  const parts = value.split(':')
+  if (parts.length !== 3) return null
+  const [prefix, nodeId, interfaceId] = parts
+  if (prefix !== INTERFACE_SELECTION_PREFIX || !nodeId || !interfaceId) {
+    return null
+  }
+  return { nodeId, interfaceId }
+}
+
+const getInterfaces = (node: Node<NodeData>): NodeInterface[] => {
+  if (!node.data || !Array.isArray(node.data.interfaces)) return []
+  return node.data.interfaces as NodeInterface[]
+}
+
+export const addInterfaceToNode = (
+  node: Node<NodeData>,
+  iface: NodeInterface
+): Node<NodeData> => {
+  const interfaces = getInterfaces(node)
+  return {
+    ...node,
+    data: {
+      ...(node.data ?? {}),
+      interfaces: [...interfaces, iface],
+    },
+  }
+}
+
+export const createInterface = (
+  params: {
+    node: Node<NodeData>
+    direction: InterfaceDirection
+    edgeId: string
+    connectedNode: Node<NodeData>
+  }
+): NodeInterface => {
+  const { node, direction, edgeId, connectedNode } = params
+  const interfaces = getInterfaces(node)
+  const count = interfaces.filter(iface => iface.direction === direction).length
+  const baseLabel =
+    direction === 'out' ? 'Исходящий интерфейс' : 'Входящий интерфейс'
+  return {
+    id: createInterfaceId(),
+    name: `${baseLabel} ${count + 1}`,
+    direction,
+    edgeId,
+    connectedNodeId: connectedNode.id,
+    connectedNodeLabel: connectedNode.data?.label
+      ? String(connectedNode.data.label)
+      : connectedNode.id,
+    description: '',
+  }
+}
+
+export const ensureInterfacesForEdge = (
+  nodes: Node<NodeData>[],
+  edge: Edge
+): Node<NodeData>[] => {
+  const sourceIndex = nodes.findIndex(n => n.id === edge.source)
+  const targetIndex = nodes.findIndex(n => n.id === edge.target)
+  if (sourceIndex === -1 || targetIndex === -1) return nodes
+
+  let sourceNode = nodes[sourceIndex]
+  let targetNode = nodes[targetIndex]
+
+  const sourceHasInterface = getInterfaces(sourceNode).some(
+    iface => iface.edgeId === edge.id && iface.direction === 'out'
+  )
+  if (!sourceHasInterface) {
+    const newInterface = createInterface({
+      node: sourceNode,
+      direction: 'out',
+      edgeId: edge.id,
+      connectedNode: targetNode,
+    })
+    sourceNode = addInterfaceToNode(sourceNode, newInterface)
+  }
+
+  const targetHasInterface = getInterfaces(targetNode).some(
+    iface => iface.edgeId === edge.id && iface.direction === 'in'
+  )
+  if (!targetHasInterface) {
+    const newInterface = createInterface({
+      node: targetNode,
+      direction: 'in',
+      edgeId: edge.id,
+      connectedNode: sourceNode,
+    })
+    targetNode = addInterfaceToNode(targetNode, newInterface)
+  }
+
+  const updated = [...nodes]
+  updated[sourceIndex] = sourceNode
+  updated[targetIndex] = targetNode
+  return updated
+}
+
+export const ensureAllEdgeInterfaces = (
+  nodes: Node<NodeData>[],
+  edges: Edge[]
+): Node<NodeData>[] => {
+  return edges.reduce((acc, edge) => ensureInterfacesForEdge(acc, edge), nodes)
+}
+
+export const removeInterfacesByEdgeIds = (
+  node: Node<NodeData>,
+  edgeIds: string[]
+): Node<NodeData> => {
+  if (!node.data || !Array.isArray(node.data.interfaces)) return node
+  const interfaces = node.data.interfaces as NodeInterface[]
+  const filtered = interfaces.filter(iface => !edgeIds.includes(iface.edgeId))
+  if (filtered.length === interfaces.length) return node
+  return {
+    ...node,
+    data: { ...(node.data ?? {}), interfaces: filtered },
+  }
+}
+
+export const updateConnectedLabels = (
+  nodes: Node<NodeData>[],
+  nodeId: string,
+  newLabel: string
+): Node<NodeData>[] => {
+  return nodes.map(node => {
+    if (!node.data || !Array.isArray(node.data.interfaces)) return node
+    const interfaces = node.data.interfaces as NodeInterface[]
+    const updated = interfaces.map(iface =>
+      iface.connectedNodeId === nodeId
+        ? { ...iface, connectedNodeLabel: newLabel }
+        : iface
+    )
+    const hasChanges = interfaces.some(
+      (iface, idx) => iface.connectedNodeId === nodeId && updated[idx] !== iface
+    )
+    if (!hasChanges) return node
+    return { ...node, data: { ...(node.data ?? {}), interfaces: updated } }
+  })
+}


### PR DESCRIPTION
## Summary
- add reusable helpers for node interface tracking and selection handling
- extend the network slice, canvas behavior, and new context/popup components to create and display interfaces on channel creation
- enhance the properties panel to edit interface details and keep connected labels in sync

## Testing
- npm run test *(fails: vitest: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68c8de3be1b483339f8aaed573fdba43