### PR TITLE
Enable scrolling for properties panel column

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,7 +22,10 @@ export default function App() {
         <div className="flex">
           <Canvas />
         </div>
-        <div style={{ display: selectedId ? 'block' : 'none' }}>
+        <div
+          style={{ display: selectedId ? 'block' : 'none' }}
+          className="h-full min-h-0 overflow-y-auto"
+        >
           <PropertiesPanel />
         </div>
         <Toaster position="top-right" />

--- a/frontend/src/components/PropertiesPanel.tsx
+++ b/frontend/src/components/PropertiesPanel.tsx
@@ -235,7 +235,10 @@ export default function PropertiesPanel() {
     const descriptionTooltip = 'Краткое описание или заметка для интерфейса.'
 
     return (
-      <div className="bg-white border-l px-4 py-6 overflow-y-auto" data-testid="properties-panel">
+      <div
+        className="min-h-full bg-white border-l px-4 py-6"
+        data-testid="properties-panel"
+      >
         <div className="font-semibold mb-4">ИНТЕРФЕЙС • {nodeTitle}</div>
         <div className="text-sm text-gray-600 space-y-1 mb-4">
           <div>Направление: {directionLabels[iface.direction]}</div>


### PR DESCRIPTION
## Summary
- add vertical scrolling to the properties column container when it is visible
- ensure the properties panel content stretches to fill the column height for consistent styling

## Testing
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68c8fd3628d0833396cd05df675feb67