### PR TITLE
Add processing configuration UI for satellite and processing nodes

### DIFF
--- a/frontend/src/components/Canvas.tsx
+++ b/frontend/src/components/Canvas.tsx
@@ -40,6 +40,11 @@ import {
   createInterface,
   NodeData,
 } from '../utils/interfaces'
+import {
+  createDefaultProcessing,
+  generateNodeCode,
+  hasProcessing,
+} from '../utils/nodeProcessing'
 import { useCallback, useEffect, useState } from 'react'
 import NearbyPopup from './NearbyPopup'
 import NodeContextMenu from './NodeContextMenu'
@@ -231,11 +236,16 @@ export default function Canvas() {
       if (ALTITUDE_RANGES[type]) {
         data.altitude = ALTITUDE_RANGES[type].min
       }
+      if (hasProcessing(type)) {
+        const code = generateNodeCode(type, nodes)
+        if (code) data.code = code
+        data.processing = createDefaultProcessing()
+      }
       dispatch(addNode({ id, type, position, data }))
       dispatch(setAddingType(null))
       toast.success('Узел добавлен')
     },
-    [dispatch, reactFlow]
+    [dispatch, reactFlow, nodes]
   )
 
   const onDragOver = useCallback((event: React.DragEvent) => {

--- a/frontend/src/utils/interfaces.ts
+++ b/frontend/src/utils/interfaces.ts
@@ -26,12 +26,26 @@ export interface NodeInterface {
   distribution?: string
 }
 
+export interface RoutingRule {
+  type: number
+  outPort: number
+}
+
+export interface ProcessingConfig {
+  serviceLines: number
+  queue: number
+  mu: number
+  routing: RoutingRule[]
+}
+
 export interface NodeData {
   label?: string
   lat?: number
   lon?: number
   altitude?: number
   location?: string
+  code?: string
+  processing?: ProcessingConfig
   interfaces?: NodeInterface[]
   [key: string]: unknown
 }

--- a/frontend/src/utils/nodeProcessing.ts
+++ b/frontend/src/utils/nodeProcessing.ts
@@ -1,0 +1,93 @@
+import type { Node } from 'reactflow'
+import type { NodeData, ProcessingConfig, RoutingRule } from './interfaces'
+
+const CODE_PREFIX_MAP: Record<string, string> = {
+  leo: 'SC',
+  meo: 'SC',
+  geo: 'SC',
+  haps: 'HAPS',
+  gnd: 'ES',
+}
+
+const PROCESSING_NODE_TYPES = new Set(['leo', 'meo', 'geo', 'haps', 'gnd'])
+
+export const hasProcessing = (type?: string | null): boolean =>
+  !!type && PROCESSING_NODE_TYPES.has(type)
+
+export const getCodePrefix = (type?: string | null): string | null => {
+  if (!type) return null
+  return CODE_PREFIX_MAP[type] ?? null
+}
+
+export const createDefaultProcessing = (): ProcessingConfig => ({
+  serviceLines: 1,
+  queue: 0,
+  mu: 1,
+  routing: [
+    { type: 1, outPort: 1 },
+    { type: 2, outPort: 2 },
+  ],
+})
+
+export const normalizeRouting = (routing?: RoutingRule[]): RoutingRule[] => {
+  if (!Array.isArray(routing) || routing.length === 0) {
+    const defaults = createDefaultProcessing()
+    return defaults.routing
+  }
+
+  return routing.map(rule => {
+    const type = Math.max(1, Math.floor(Number(rule.type)))
+    const outPort = Math.max(1, Math.floor(Number(rule.outPort)))
+    return { type, outPort }
+  })
+}
+
+export const normalizeProcessing = (
+  config?: Partial<ProcessingConfig> | null
+): ProcessingConfig => {
+  const defaults = createDefaultProcessing()
+  if (!config) return defaults
+
+  const serviceLines =
+    typeof config.serviceLines === 'number' && config.serviceLines >= 1
+      ? Math.floor(config.serviceLines)
+      : defaults.serviceLines
+
+  const queue =
+    typeof config.queue === 'number' && config.queue >= 0
+      ? Math.floor(config.queue)
+      : defaults.queue
+
+  const mu =
+    typeof config.mu === 'number' && config.mu > 0 ? config.mu : defaults.mu
+
+  const routing = normalizeRouting(config.routing)
+
+  return { serviceLines, queue, mu, routing }
+}
+
+export const generateNodeCode = (
+  type: string | undefined,
+  nodes: Node<NodeData>[]
+): string | null => {
+  const prefix = getCodePrefix(type)
+  if (!prefix) return null
+
+  const used = new Set<number>()
+  nodes.forEach(node => {
+    const code = node.data?.code
+    if (typeof code !== 'string') return
+    if (!code.startsWith(prefix)) return
+    const suffix = parseInt(code.slice(prefix.length), 10)
+    if (!Number.isNaN(suffix)) {
+      used.add(suffix)
+    }
+  })
+
+  let idx = 1
+  while (used.has(idx)) {
+    idx += 1
+  }
+
+  return `${prefix}${idx}`
+}


### PR DESCRIPTION
## Summary
- add default processing configuration and code generation when creating processing-capable nodes
- extend the properties panel with inputs for node code, service lines, queue, processing rate, and routing table
- add shared processing utilities/types and enable horizontal scrolling in the properties panel

## Testing
- npm test *(fails: missing vite package because the registry returns HTTP 403, preventing vitest from loading)*

------
https://chatgpt.com/codex/tasks/task_e_68ca26113c0c8333bbfd4db173fa624e