### PR TITLE
feat: add context menu deletion

### DIFF
--- a/frontend/src/components/Canvas.tsx
+++ b/frontend/src/components/Canvas.tsx
@@ -18,7 +18,6 @@ import {
   addNode,
   setElements,
   updateNode,
-  removeElement,
   select,
   setAddingType,
   openNearby,
@@ -49,6 +48,7 @@ import { useCallback, useEffect, useState } from 'react'
 import NearbyPopup from './NearbyPopup'
 import NodeContextMenu from './NodeContextMenu'
 import InterfacesPopup from './InterfacesPopup'
+import DeleteConfirmationDialog from './DeleteConfirmationDialog'
 import toast from 'react-hot-toast'
 
 const nodeTypes: NodeTypes = {
@@ -292,11 +292,7 @@ export default function Canvas() {
         onNodeClick={(event, node) => {
           dispatch(closeNodeMenu())
           dispatch(closeInterfaces())
-          if (addingType === 'delete') {
-            dispatch(removeElement(node.id))
-            toast.success('Удалено')
-            dispatch(closeNearby())
-          } else if (addingType === 'link') {
+          if (addingType === 'link') {
             if (!linkSource) {
               setLinkSource(node.id)
               dispatch(updateNode({ ...node, className: 'ring-2 ring-blue-500' }))
@@ -347,10 +343,7 @@ export default function Canvas() {
         onEdgeClick={(_, edge) => {
           dispatch(closeNodeMenu())
           dispatch(closeInterfaces())
-          if (addingType === 'delete') {
-            dispatch(removeElement(edge.id))
-            toast.success('Удалено')
-          } else if (addingType !== 'link') {
+          if (addingType !== 'link') {
             dispatch(select(edge.id))
           }
           dispatch(closeNearby())
@@ -372,6 +365,7 @@ export default function Canvas() {
       <NearbyPopup />
       <NodeContextMenu />
       <InterfacesPopup />
+      <DeleteConfirmationDialog />
     </div>
   )
 }

--- a/frontend/src/components/DeleteConfirmationDialog.tsx
+++ b/frontend/src/components/DeleteConfirmationDialog.tsx
@@ -1,0 +1,55 @@
+import { useAppDispatch, useAppSelector } from '../hooks'
+import {
+  closeDeleteConfirmation,
+  removeElement,
+} from '../features/network/networkSlice'
+import toast from 'react-hot-toast'
+
+export default function DeleteConfirmationDialog() {
+  const dispatch = useAppDispatch()
+  const confirmation = useAppSelector(state => state.network.deleteConfirmation)
+
+  if (!confirmation) return null
+
+  const { elementId, elementType, label } = confirmation
+  const title = label ? `Удалить «${label}»?` : 'Удалить выбранный объект?'
+  const description =
+    elementType === 'node'
+      ? 'Связанные соединения и интерфейсы также будут удалены.'
+      : 'Связанные данные также будут удалены.'
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4"
+      onClick={() => dispatch(closeDeleteConfirmation())}
+    >
+      <div
+        className="max-w-md w-full bg-white rounded-lg shadow-lg p-6 flex flex-col gap-4"
+        onClick={event => event.stopPropagation()}
+      >
+        <div className="text-lg font-semibold text-gray-900">{title}</div>
+        <p className="text-sm text-gray-600">{description}</p>
+        <div className="flex items-center justify-end gap-3">
+          <button
+            type="button"
+            className="px-4 py-2 text-sm border rounded"
+            onClick={() => dispatch(closeDeleteConfirmation())}
+          >
+            Отмена
+          </button>
+          <button
+            type="button"
+            className="px-4 py-2 text-sm rounded bg-red-600 text-white hover:bg-red-700"
+            onClick={() => {
+              dispatch(removeElement(elementId))
+              dispatch(closeDeleteConfirmation())
+              toast.success('Объект удалён')
+            }}
+          >
+            Удалить
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/NodeContextMenu.tsx
+++ b/frontend/src/components/NodeContextMenu.tsx
@@ -3,11 +3,12 @@ import { useAppDispatch, useAppSelector } from '../hooks'
 import {
   closeNodeMenu,
   openInterfaces,
+  openDeleteConfirmation,
 } from '../features/network/networkSlice'
 
 export default function NodeContextMenu() {
   const dispatch = useAppDispatch()
-  const { contextMenu, selectedId } = useAppSelector(state => state.network)
+  const { contextMenu, selectedId, nodes } = useAppSelector(state => state.network)
   const ref = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -30,11 +31,14 @@ export default function NodeContextMenu() {
   if (left + width > rightBoundary) left = rightBoundary - width - 10
   if (left < leftBoundary) left = leftBoundary + 10
 
+  const node = nodes.find(n => n.id === contextMenu.nodeId)
+  const nodeLabel = node?.data?.label ? String(node.data.label) : contextMenu.nodeId
+
   return (
     <div
       ref={ref}
       style={{ position: 'absolute', left, top, width }}
-      className="bg-white border rounded shadow z-50 text-sm"
+      className="bg-white border rounded shadow z-50 text-sm divide-y"
       onClick={event => event.stopPropagation()}
     >
       <button
@@ -46,6 +50,22 @@ export default function NodeContextMenu() {
         }}
       >
         Интерфейсы
+      </button>
+      <button
+        type="button"
+        className="block w-full text-left px-3 py-2 hover:bg-gray-100 text-red-600"
+        onClick={() => {
+          dispatch(
+            openDeleteConfirmation({
+              elementId: contextMenu.nodeId,
+              elementType: 'node',
+              label: nodeLabel,
+            })
+          )
+          dispatch(closeNodeMenu())
+        }}
+      >
+        Удалить
       </button>
     </div>
   )

--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -1,5 +1,4 @@
-import PaletteButton from './PaletteButton'
-import { TrashIcon, ArrowDownTrayIcon, ArrowUpTrayIcon } from '@heroicons/react/24/solid'
+import { ArrowDownTrayIcon, ArrowUpTrayIcon } from '@heroicons/react/24/solid'
 import { useAppSelector } from '../hooks'
 import { useCallback, useEffect } from 'react'
 import toast from 'react-hot-toast'
@@ -63,7 +62,6 @@ export default function TopBar() {
           <ArrowDownTrayIcon className="w-5 h-5" />
         </button>
       </div>
-      <PaletteButton icon={TrashIcon} label="Удалить" type="delete" />
     </div>
   )
 }

--- a/frontend/src/features/network/networkSlice.ts
+++ b/frontend/src/features/network/networkSlice.ts
@@ -18,6 +18,7 @@ const initialState: NetworkState = {
   nearby: null,
   contextMenu: null,
   interfacePopup: null,
+  deleteConfirmation: null,
 }
 
 const networkSlice = createSlice({
@@ -74,6 +75,7 @@ const networkSlice = createSlice({
       const id = action.payload
       state.contextMenu = null
       state.interfacePopup = null
+      state.deleteConfirmation = null
 
       const selection = parseInterfaceSelectionId(state.selectedId)
       let removedEdgeIds: string[] = []
@@ -166,6 +168,22 @@ const networkSlice = createSlice({
     closeInterfaces(state) {
       state.interfacePopup = null
     },
+    openDeleteConfirmation(
+      state,
+      action: PayloadAction<{
+        elementId: string
+        elementType: 'node' | 'edge'
+        label?: string
+      }>
+    ) {
+      state.deleteConfirmation = action.payload
+      state.contextMenu = null
+      state.interfacePopup = null
+      state.nearby = null
+    },
+    closeDeleteConfirmation(state) {
+      state.deleteConfirmation = null
+    },
   },
 })
 
@@ -185,5 +203,7 @@ export const {
   closeNodeMenu,
   openInterfaces,
   closeInterfaces,
+  openDeleteConfirmation,
+  closeDeleteConfirmation,
 } = networkSlice.actions
 export default networkSlice.reducer

--- a/frontend/src/features/network/types.ts
+++ b/frontend/src/features/network/types.ts
@@ -10,4 +10,7 @@ export interface NetworkState {
   nearby: { ids: string[]; x: number; y: number } | null
   contextMenu: { nodeId: string; x: number; y: number } | null
   interfacePopup: { nodeId: string; x: number; y: number } | null
+  deleteConfirmation:
+    | { elementId: string; elementType: 'node' | 'edge'; label?: string }
+    | null
 }


### PR DESCRIPTION
## Summary
- add node context menu option to delete canvas elements with confirmation
- store delete confirmation state and close related popups when removing elements
- remove delete palette button and show confirmation overlay for removals

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68ca39fa99848333b205a90e0c214090