### PR TITLE
Hide connection handles and enlarge arrowheads

### DIFF
--- a/frontend/src/components/Canvas.tsx
+++ b/frontend/src/components/Canvas.tsx
@@ -106,6 +106,8 @@ export default function Canvas() {
         markerEnd: {
           type: MarkerType.ArrowClosed,
           color: 'black',
+          width: 25,
+          height: 25,
         },
       }
 
@@ -283,7 +285,12 @@ export default function Canvas() {
         onConnect={onConnect}
         defaultEdgeOptions={{
           type: 'floating',
-          markerEnd: { type: MarkerType.ArrowClosed, color: 'black' },
+          markerEnd: {
+            type: MarkerType.ArrowClosed,
+            color: 'black',
+            width: 25,
+            height: 25,
+          },
         }}
         onNodeContextMenu={(event, node) => {
           event.preventDefault()

--- a/frontend/src/components/NetworkNode.tsx
+++ b/frontend/src/components/NetworkNode.tsx
@@ -1,3 +1,4 @@
+import type { CSSProperties } from 'react'
 import { NodeProps, useStore, Handle, Position } from 'reactflow'
 import classNames from 'classnames'
 import { CubeIcon } from '@heroicons/react/24/solid'
@@ -17,6 +18,12 @@ const typeImages: Record<string, string> = {
   haps: hapsPng,
 }
 
+const hiddenHandleStyle: CSSProperties = {
+  opacity: 0,
+  background: 'transparent',
+  border: 'none',
+}
+
 export default function NetworkNode({ data, type, selected, className }: NodeProps<any>) {
   const zoom = useStore(state => state.transform[2])
   const src = type ? typeImages[type] : undefined
@@ -33,7 +40,12 @@ export default function NetworkNode({ data, type, selected, className }: NodePro
         )}
         style={{ width: 8, height: 8 }}
       >
-        <Handle type="target" position={Position.Left} className="w-1 h-1" />
+        <Handle
+          type="target"
+          position={Position.Left}
+          className="w-1 h-1"
+          style={hiddenHandleStyle}
+        />
         {src ? (
           <img
             src={src}
@@ -44,7 +56,12 @@ export default function NetworkNode({ data, type, selected, className }: NodePro
         ) : (
           <CubeIcon className="w-2 h-2" aria-hidden />
         )}
-        <Handle type="source" position={Position.Right} className="w-1 h-1" />
+        <Handle
+          type="source"
+          position={Position.Right}
+          className="w-1 h-1"
+          style={hiddenHandleStyle}
+        />
       </div>
     )
   }
@@ -58,7 +75,12 @@ export default function NetworkNode({ data, type, selected, className }: NodePro
         className
       )}
     >
-      <Handle type="target" position={Position.Left} className="w-2 h-2" />
+      <Handle
+        type="target"
+        position={Position.Left}
+        className="w-2 h-2"
+        style={hiddenHandleStyle}
+      />
       {src ? (
         <img
           src={src}
@@ -70,7 +92,12 @@ export default function NetworkNode({ data, type, selected, className }: NodePro
         <CubeIcon className="w-4 h-4" aria-hidden />
       )}
       <span>{data?.label}</span>
-      <Handle type="source" position={Position.Right} className="w-2 h-2" />
+      <Handle
+        type="source"
+        position={Position.Right}
+        className="w-2 h-2"
+        style={hiddenHandleStyle}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- hide the left and right connection handles so the dots on each node disappear while preserving link creation
- enlarge the arrowhead marker size for both newly created edges and default edge options

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca48c252b883338528b242459d4309