### PR TITLE
feat: enrich topology model and support AS/SSOP nodes

### DIFF
--- a/frontend/src/components/PaletteBar.tsx
+++ b/frontend/src/components/PaletteBar.tsx
@@ -4,6 +4,7 @@ import MeoIcon from "../img/meo.png"
 import GeoIcon from "../img/geo.png"
 import GndIcon from "../img/gnd.png"
 import HaspIcon from "../img/hasp.png"
+import { UserIcon, GlobeAltIcon } from "@heroicons/react/24/solid"
 
 
 const items = [
@@ -12,6 +13,8 @@ const items = [
   { type: "geo", icon: GeoIcon, label: "Геостационарная орбита"},
   { type: "gnd", icon: GndIcon, label: "Наземная станция" },
   { type: "haps", icon: HaspIcon, label: "Высотная платформа" },
+  { type: "as", icon: UserIcon, label: "Узел AS (абонент)" },
+  { type: "ssop", icon: GlobeAltIcon, label: "Узел SSOP (внешняя сеть)" },
 ];
 
 export default function PaletteBar() {

--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -16,10 +16,12 @@ function FloppyDiskIcon(props: SVGProps<SVGSVGElement>) {
 
 export default function TopBar() {
   const dispatch = useAppDispatch()
-  const { nodes, edges, topologyId, addingType } = useAppSelector(state => state.network)
+  const { nodes, edges, model, topologyId, addingType } = useAppSelector(
+    state => state.network
+  )
 
   const handleDownload = () => {
-    const json = JSON.stringify({ nodes, edges }, null, 2)
+    const json = JSON.stringify({ model, nodes, edges }, null, 2)
     const blob = new Blob([json], { type: 'application/json' })
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')
@@ -34,7 +36,7 @@ export default function TopBar() {
     const res = await fetch(`/api/topologies/${topologyId}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ data: { nodes, edges } }),
+      body: JSON.stringify({ data: { model, nodes, edges } }),
     })
     if (res.ok) {
       toast.success('Сохранено')

--- a/frontend/src/components/TopologyModal.tsx
+++ b/frontend/src/components/TopologyModal.tsx
@@ -2,11 +2,12 @@ import { useEffect, useState } from 'react'
 import { useAppDispatch } from '../hooks'
 import { setTopology } from '../features/network/networkSlice'
 import type { Node, Edge } from 'reactflow'
+import { createDefaultModelConfig, ModelConfig } from '../domain/types'
 
 interface Topology {
   id: number
   name: string
-  data: { nodes: Node[]; edges: Edge[] }
+  data: { model: ModelConfig; nodes: Node[]; edges: Edge[] }
   updated_at: string
 }
 
@@ -28,7 +29,12 @@ export default function TopologyModal({ onClose }: Props) {
 
   const handleSelect = (topology: Topology) => {
     dispatch(
-      setTopology({ id: topology.id, nodes: topology.data.nodes, edges: topology.data.edges })
+      setTopology({
+        id: topology.id,
+        model: topology.data.model ?? createDefaultModelConfig(),
+        nodes: topology.data.nodes,
+        edges: topology.data.edges,
+      })
     )
     onClose()
   }
@@ -38,12 +44,20 @@ export default function TopologyModal({ onClose }: Props) {
     const res = await fetch('/api/topologies', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name, data: { nodes: [], edges: [] } }),
+      body: JSON.stringify({
+        name,
+        data: { model: createDefaultModelConfig(), nodes: [], edges: [] },
+      }),
     })
     if (res.ok) {
       const topology: Topology = await res.json()
       dispatch(
-        setTopology({ id: topology.id, nodes: topology.data.nodes, edges: topology.data.edges })
+        setTopology({
+          id: topology.id,
+          model: topology.data.model ?? createDefaultModelConfig(),
+          nodes: topology.data.nodes,
+          edges: topology.data.edges,
+        })
       )
       onClose()
     }

--- a/frontend/src/domain/io.ts
+++ b/frontend/src/domain/io.ts
@@ -1,9 +1,12 @@
-import { Topology } from './types'
+import { Topology, createDefaultModelConfig } from './types'
 
 export const exportTopology = (topology: Topology): string =>
   JSON.stringify(topology)
 
 export const importTopology = (json: string): Topology => {
   const parsed = JSON.parse(json)
+  if (!parsed.model) {
+    parsed.model = createDefaultModelConfig()
+  }
   return parsed as Topology
 }

--- a/frontend/src/domain/operations.test.ts
+++ b/frontend/src/domain/operations.test.ts
@@ -3,6 +3,7 @@ import {
   Node,
   NodeType,
   Topology,
+  createDefaultModelConfig,
   onConnect,
   removeEdge,
   exportTopology,
@@ -18,7 +19,11 @@ const makeNode = (id: string, type: NodeType): Node => ({
   outPorts: [],
 })
 
-const emptyTopology = (nodes: Node[]): Topology => ({ nodes, edges: [] })
+const emptyTopology = (nodes: Node[]): Topology => ({
+  model: createDefaultModelConfig(),
+  nodes,
+  edges: [],
+})
 
 describe('auto indexing and connection', () => {
   it('creates ports automatically and keeps indices stable', () => {
@@ -107,7 +112,8 @@ describe('edge removal cleanup', () => {
           dir: 'out',
           idx: 1,
           label: 'p1',
-          params: { q: 0, mu: 0 },
+          queue: { q_out: 0 },
+          service: { mu_out: 1 },
           persistent: false,
           locked: false,
         },
@@ -122,7 +128,8 @@ describe('edge removal cleanup', () => {
           dir: 'in',
           idx: 1,
           label: 'p2',
-          params: { q: 0, mu: 0 },
+          queue: { q_in: 0 },
+          service: { mu_in: 1 },
           persistent: false,
           locked: false,
         },

--- a/frontend/src/domain/types.ts
+++ b/frontend/src/domain/types.ts
@@ -8,9 +8,35 @@ export enum NodeType {
 
 export type PortDir = 'in' | 'out'
 
-export interface PortParams {
-  q: number
-  mu: number
+export interface PortQueueConfig {
+  q_in?: number
+  q_out?: number
+}
+
+export interface PortServiceConfig {
+  mu_in?: number
+  mu_out?: number
+  servers_in?: number
+  servers_out?: number
+  dist_in?: string
+  dist_out?: string
+}
+
+export interface PortNextHopTerminal {
+  terminal: 'to_AS' | 'to_SSOP'
+}
+
+export interface PortNextHopNode {
+  nodeId: string
+  inPortIdx: number
+}
+
+export type PortNextHop = PortNextHopTerminal | PortNextHopNode
+
+export interface PortLinkPhysics {
+  bandwidth?: number
+  propDelay?: number
+  packetSize?: number
 }
 
 export interface Port {
@@ -19,15 +45,25 @@ export interface Port {
   dir: PortDir
   idx: number
   label: string
-  params: PortParams
+  queue: PortQueueConfig
+  service: PortServiceConfig
   persistent: boolean
   locked: boolean
+  nextHop?: PortNextHop
+  linkPhysics?: PortLinkPhysics
+}
+
+export interface NodeProcessingRoutingRule {
+  type: number
+  outPort: number
 }
 
 export interface NodeProcessing {
   serviceLines: number
   q: number
   mu: number
+  dist?: string
+  routingTable: NodeProcessingRoutingRule[]
 }
 
 export interface NodePosition {
@@ -49,16 +85,75 @@ export interface Node {
 export interface EdgeEndpoint {
   nodeId: string
   portId: string
+  portIdx: number
+}
+
+export interface EdgeLinkConfig {
+  distType?: string
+  mu?: number
+  tMean?: number
+  lossProb?: number
+  availability?: { mtbf: number; mttr: number }
 }
 
 export interface Edge {
   id: string
   from: EdgeEndpoint
-  to: EdgeEndpoint
+  to?: EdgeEndpoint
+  terminal?: 'to_AS' | 'to_SSOP'
+  direction?: 'uni' | 'bi'
+  label?: string
+  link?: EdgeLinkConfig
   meta?: Record<string, unknown>
 }
 
+export interface SimulationConfig {
+  duration: number
+}
+
+export interface TimeConfig {
+  unit?: string
+}
+
+export interface RngConfig {
+  seed?: number
+}
+
+export interface TrafficCapacityConfig {
+  dist: string
+  params: Record<string, number>
+}
+
+export interface TrafficConfig {
+  capacity: TrafficCapacityConfig
+}
+
+export interface PacketConfig {
+  mtu: number
+}
+
+export interface ModelConfig {
+  model: { id: string }
+  sim: SimulationConfig
+  time?: TimeConfig
+  rng?: RngConfig
+  traffic: TrafficConfig
+  packet: PacketConfig
+  dataTypes?: number[]
+}
+
 export interface Topology {
+  model: ModelConfig
   nodes: Node[]
   edges: Edge[]
 }
+
+export const createDefaultModelConfig = (): ModelConfig => ({
+  model: { id: 'model-1' },
+  sim: { duration: 1_000 },
+  time: { unit: 's' },
+  rng: { seed: 1 },
+  traffic: { capacity: { dist: 'Deterministic', params: { minBytes: 1024, maxBytes: 1024 } } },
+  packet: { mtu: 65_535 },
+  dataTypes: [1, 2],
+})

--- a/frontend/src/features/network/networkSlice.ts
+++ b/frontend/src/features/network/networkSlice.ts
@@ -9,10 +9,12 @@ import {
 import type { NodeData, NodeInterface } from '../../utils/interfaces'
 import { NetworkState } from './types'
 import { prepareEdges } from '../../utils/edges'
+import { createDefaultModelConfig, ModelConfig } from '../../domain/types'
 
 const initialState: NetworkState = {
   nodes: [],
   edges: [],
+  model: createDefaultModelConfig(),
   topologyId: null,
   selectedId: null,
   addingType: null,
@@ -37,11 +39,13 @@ const networkSlice = createSlice({
       state,
       action: PayloadAction<{
         id: number
+        model?: ModelConfig
         nodes: Node<NodeData>[]
         edges: Edge[]
       }>
     ) {
       state.topologyId = action.payload.id
+      state.model = action.payload.model ?? createDefaultModelConfig()
       const normalizedNodes = action.payload.nodes.map(node => {
         const data = { ...(node.data ?? {}) }
         if (Array.isArray(data.interfaces)) {
@@ -58,6 +62,9 @@ const networkSlice = createSlice({
       state.nearby = null
       state.contextMenu = null
       state.interfacePopup = null
+    },
+    setModel(state, action: PayloadAction<ModelConfig>) {
+      state.model = action.payload
     },
     addNode(state, action: PayloadAction<Node<NodeData>>) {
       state.nodes.push(action.payload)
@@ -203,6 +210,7 @@ export const {
   removeElement,
   select,
   setAddingType,
+  setModel,
   openNearby,
   closeNearby,
   openNodeMenu,

--- a/frontend/src/features/network/types.ts
+++ b/frontend/src/features/network/types.ts
@@ -1,9 +1,11 @@
 import type { Node, Edge } from 'reactflow'
 import type { NodeData } from '../../utils/interfaces'
+import type { ModelConfig } from '../../domain/types'
 
 export interface NetworkState {
   nodes: Node<NodeData>[]
   edges: Edge[]
+  model: ModelConfig
   topologyId: number | null
   selectedId: string | null
   addingType: string | null

--- a/frontend/src/utils/generatorConfig.ts
+++ b/frontend/src/utils/generatorConfig.ts
@@ -1,0 +1,21 @@
+import { GeneratorConfig } from './interfaces'
+
+const GENERATOR_MAP: Record<string, GeneratorConfig> = {
+  as: {
+    lambda: 1,
+    typeData: 1,
+    capacitySource: 'capacity',
+    target: { nodeId: '', inPortId: undefined, inPortIdx: undefined },
+  },
+  ssop: {
+    lambda: 1,
+    typeData: 2,
+    capacitySource: 'capacity',
+    target: { nodeId: '', inPortId: undefined, inPortIdx: undefined },
+  },
+}
+
+export const createDefaultGenerator = (type: string): GeneratorConfig | null => {
+  const template = GENERATOR_MAP[type]
+  return template ? { ...template, target: { ...template.target } } : null
+}

--- a/frontend/src/utils/nodeProcessing.ts
+++ b/frontend/src/utils/nodeProcessing.ts
@@ -23,7 +23,8 @@ export const createDefaultProcessing = (): ProcessingConfig => ({
   serviceLines: 1,
   queue: 0,
   mu: 1,
-  routing: [
+  dist: 'Exponential',
+  routingTable: [
     { type: 1, outPort: 1 },
     { type: 2, outPort: 2 },
   ],
@@ -32,7 +33,7 @@ export const createDefaultProcessing = (): ProcessingConfig => ({
 export const normalizeRouting = (routing?: RoutingRule[]): RoutingRule[] => {
   if (!Array.isArray(routing) || routing.length === 0) {
     const defaults = createDefaultProcessing()
-    return defaults.routing
+    return defaults.routingTable
   }
 
   return routing.map(rule => {
@@ -61,9 +62,16 @@ export const normalizeProcessing = (
   const mu =
     typeof config.mu === 'number' && config.mu > 0 ? config.mu : defaults.mu
 
-  const routing = normalizeRouting(config.routing)
+  const routing = normalizeRouting(
+    Array.isArray((config as any).routingTable)
+      ? ((config as any).routingTable as RoutingRule[])
+      : config.routing ?? undefined
+  )
+  const dist = typeof config.dist === 'string' && config.dist
+    ? config.dist
+    : defaults.dist
 
-  return { serviceLines, queue, mu, routing }
+  return { serviceLines, queue, mu, dist, routingTable: routing }
 }
 
 export const generateNodeCode = (


### PR DESCRIPTION
## Summary
- extend domain topology types with model-level settings, richer port metadata, and generator descriptors
- add AS/SSOP nodes to the palette, seed generator defaults during node creation, and surface global/generator forms in the properties panel
- persist global configuration during export/save flows and fall back to defaults when loading legacy topologies

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68ca60c137a08333b02a7c3026c3b129