### PR TITLE
Prevent redundant updates in setElements reducer

### DIFF
--- a/frontend/src/features/network/networkSlice.ts
+++ b/frontend/src/features/network/networkSlice.ts
@@ -32,8 +32,27 @@ const networkSlice = createSlice({
       state,
       action: PayloadAction<{ nodes: Node<NodeData>[]; edges: Edge[] }>
     ) {
-      state.nodes = action.payload.nodes
-      state.edges = prepareEdges(action.payload.edges)
+      const { nodes, edges } = action.payload
+
+      const nodesChanged =
+        state.nodes.length !== nodes.length ||
+        state.nodes.some((node, idx) => node !== nodes[idx])
+
+      const edgesChanged =
+        state.edges.length !== edges.length ||
+        state.edges.some((edge, idx) => edge !== edges[idx])
+
+      if (!nodesChanged && !edgesChanged) {
+        return
+      }
+
+      if (nodesChanged) {
+        state.nodes = nodes
+      }
+
+      if (edgesChanged) {
+        state.edges = prepareEdges(edges)
+      }
     },
     setTopology(
       state,


### PR DESCRIPTION
## Summary
- avoid reassigning network elements when incoming nodes and edges match the current state
- limit prepareEdges work to actual edge updates to help stop redundant rerenders

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca6cd7c6d8833392215bce0c39d0e6