### PR TITLE
Fix redundant state updates that triggered ReactFlow loop

### DIFF
--- a/frontend/src/features/network/networkSlice.ts
+++ b/frontend/src/features/network/networkSlice.ts
@@ -1,4 +1,4 @@
-import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { createSlice, PayloadAction, current } from '@reduxjs/toolkit'
 import type { Node, Edge } from 'reactflow'
 import {
   ensureAllEdgeInterfaces,
@@ -34,13 +34,16 @@ const networkSlice = createSlice({
     ) {
       const { nodes, edges } = action.payload
 
+      const currentNodes = current(state.nodes)
+      const currentEdges = current(state.edges)
+
       const nodesChanged =
-        state.nodes.length !== nodes.length ||
-        state.nodes.some((node, idx) => node !== nodes[idx])
+        currentNodes.length !== nodes.length ||
+        currentNodes.some((node, idx) => node !== nodes[idx])
 
       const edgesChanged =
-        state.edges.length !== edges.length ||
-        state.edges.some((edge, idx) => edge !== edges[idx])
+        currentEdges.length !== edges.length ||
+        currentEdges.some((edge, idx) => edge !== edges[idx])
 
       if (!nodesChanged && !edgesChanged) {
         return


### PR DESCRIPTION
## Summary
- avoid redundant updates in the `setElements` reducer by comparing against the current draft using `immer`'s `current`
- ensure nodes and edges are only written back to the store when they actually changed

## Testing
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68ca73ebe8508333bc4136c55583102c