### PR TITLE
feat: complete channel configuration UI

### DIFF
--- a/frontend/src/domain/operations.test.ts
+++ b/frontend/src/domain/operations.test.ts
@@ -136,9 +136,16 @@ describe('edge removal cleanup', () => {
       ],
     }
     const topo: Topology = {
+      model: createDefaultModelConfig(),
       nodes: [a, b],
       edges: [
-        { id: 'e1', from: { nodeId: 'a', portId: 'p1' }, to: { nodeId: 'b', portId: 'p2' } },
+        {
+          id: 'e1',
+          from: { nodeId: 'a', portId: 'p1', outPortIdx: 1 },
+          to: { kind: 'node', nodeId: 'b', portId: 'p2', inPortIdx: 1 },
+          direction: 'uni',
+          muPolicy: 'manual',
+        },
       ],
     }
     const updated = removeEdge(topo, 'e1')

--- a/frontend/src/domain/types.ts
+++ b/frontend/src/domain/types.ts
@@ -82,14 +82,34 @@ export interface Node {
   meta?: Record<string, unknown>
 }
 
-export interface EdgeEndpoint {
+export interface ChannelFromEndpoint {
   nodeId: string
-  portId: string
-  portIdx: number
+  outPortIdx: number
+  portId?: string
 }
 
-export interface EdgeLinkConfig {
-  distType?: string
+export interface ChannelToNodeEndpoint {
+  kind: 'node'
+  nodeId: string
+  inPortIdx: number
+  portId?: string
+}
+
+export interface ChannelToTerminalEndpoint {
+  kind: 'terminal'
+  terminal: 'to_AS' | 'to_SSOP'
+}
+
+export type ChannelToEndpoint =
+  | ChannelToNodeEndpoint
+  | ChannelToTerminalEndpoint
+
+export type ChannelDirection = 'uni' | 'bi'
+
+export type ChannelMuPolicy = 'auto_from_physics' | 'manual'
+
+export interface ChannelLinkConfig {
+  distType?: 'Exponential' | 'Deterministic' | 'Erlang' | 'Lognormal'
   mu?: number
   tMean?: number
   lossProb?: number
@@ -98,12 +118,15 @@ export interface EdgeLinkConfig {
 
 export interface Edge {
   id: string
-  from: EdgeEndpoint
-  to?: EdgeEndpoint
-  terminal?: 'to_AS' | 'to_SSOP'
-  direction?: 'uni' | 'bi'
+  from: ChannelFromEndpoint
+  to: ChannelToEndpoint
+  direction?: ChannelDirection
   label?: string
-  link?: EdgeLinkConfig
+  bandwidth?: number
+  propDelay?: number
+  packetSize?: number
+  muPolicy?: ChannelMuPolicy
+  link?: ChannelLinkConfig
   meta?: Record<string, unknown>
 }
 

--- a/frontend/src/features/network/networkSlice.ts
+++ b/frontend/src/features/network/networkSlice.ts
@@ -9,6 +9,7 @@ import {
 import type { NodeData, NodeInterface } from '../../utils/interfaces'
 import { NetworkState } from './types'
 import { prepareEdges } from '../../utils/edges'
+import { attachChannelData } from '../../utils/channels'
 import { createDefaultModelConfig, ModelConfig } from '../../domain/types'
 
 const initialState: NetworkState = {
@@ -54,7 +55,8 @@ const networkSlice = createSlice({
       }
 
       if (edgesChanged) {
-        state.edges = prepareEdges(edges)
+        const edgesWithChannel = attachChannelData(edges, nodes)
+        state.edges = prepareEdges(edgesWithChannel)
       }
     },
     setTopology(
@@ -78,8 +80,13 @@ const networkSlice = createSlice({
         return normalizeNodeInterfaces({ ...node, data })
       })
       const preparedEdges = prepareEdges(action.payload.edges)
-      state.nodes = ensureAllEdgeInterfaces(normalizedNodes, preparedEdges)
-      state.edges = preparedEdges
+      const nodesWithInterfaces = ensureAllEdgeInterfaces(
+        normalizedNodes,
+        preparedEdges
+      )
+      const edgesWithChannel = attachChannelData(preparedEdges, nodesWithInterfaces)
+      state.nodes = nodesWithInterfaces
+      state.edges = edgesWithChannel
       state.selectedId = null
       state.nearby = null
       state.contextMenu = null

--- a/frontend/src/utils/channels.ts
+++ b/frontend/src/utils/channels.ts
@@ -1,0 +1,146 @@
+import type { Edge as ChannelConfig } from '../domain/types'
+import type { Edge as ReactFlowEdge, Node } from 'reactflow'
+import type { NodeData, NodeInterface } from './interfaces'
+
+export type ChannelEdgeData = {
+  channel?: ChannelConfig
+  distance?: number
+  parallelOffset?: number
+  [key: string]: unknown
+}
+
+const toNumber = (value: unknown): number | undefined => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value
+  }
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : undefined
+  }
+  return undefined
+}
+
+const convertLegacyBandwidth = (edgeData: unknown): number | undefined => {
+  if (!edgeData || typeof edgeData !== 'object') return undefined
+  const value = toNumber((edgeData as Record<string, unknown>).bandwidth)
+  if (typeof value !== 'number') return undefined
+  // Previous UI stored bandwidth in Mbit/s. Convert to bytes per second.
+  return (value * 1_000_000) / 8
+}
+
+const convertLegacyLatency = (edgeData: unknown): number | undefined => {
+  if (!edgeData || typeof edgeData !== 'object') return undefined
+  const value = toNumber((edgeData as Record<string, unknown>).latency)
+  if (typeof value !== 'number') return undefined
+  // Previous UI stored latency in milliseconds. Convert to seconds.
+  return value / 1_000
+}
+
+const getInterfaces = (
+  node: Node<NodeData> | undefined,
+  edgeId: string,
+  direction: 'in' | 'out'
+): NodeInterface | undefined => {
+  if (!node || !node.data || !Array.isArray(node.data.interfaces)) return undefined
+  return (node.data.interfaces as NodeInterface[]).find(
+    iface => iface.edgeId === edgeId && iface.direction === direction
+  )
+}
+
+export const ensureEdgeChannel = (
+  edge: ReactFlowEdge<ChannelEdgeData>,
+  nodes: Node<NodeData>[]
+): ChannelConfig => {
+  const existing = (edge.data?.channel ?? null) as ChannelConfig | null
+  const sourceNode = nodes.find(node => node.id === edge.source)
+  const targetNode = nodes.find(node => node.id === edge.target)
+
+  const sourceInterface = getInterfaces(sourceNode, edge.id, 'out')
+  const targetInterface = getInterfaces(targetNode, edge.id, 'in')
+
+  const fromNodeId = existing?.from.nodeId ?? edge.source ?? sourceNode?.id ?? ''
+  const fromOutIdx =
+    existing?.from.outPortIdx ?? sourceInterface?.idx ?? 1
+  const fromPortId = sourceInterface?.id ?? existing?.from.portId
+
+  let to: ChannelConfig['to']
+  if (existing?.to.kind === 'terminal') {
+    to = {
+      kind: 'terminal',
+      terminal: existing.to.terminal,
+    }
+  } else {
+    const nodeId =
+      (existing?.to.kind === 'node' && existing.to.nodeId) ??
+      targetNode?.id ??
+      ''
+    const inPortIdx =
+      (existing?.to.kind === 'node' && existing.to.inPortIdx) ??
+      targetInterface?.idx ??
+      1
+    const portId = targetInterface?.id ?? (existing?.to.kind === 'node' ? existing.to.portId : undefined)
+    to = {
+      kind: 'node',
+      nodeId,
+      inPortIdx,
+      portId,
+    }
+  }
+
+  const label = existing?.label ?? (typeof edge.label === 'string' ? edge.label : undefined)
+
+  const direction = existing?.direction ?? 'uni'
+  const muPolicy = existing?.muPolicy ?? 'manual'
+  const bandwidth =
+    existing?.bandwidth ?? (existing ? undefined : convertLegacyBandwidth(edge.data))
+  const propDelay =
+    existing?.propDelay ?? (existing ? undefined : convertLegacyLatency(edge.data))
+
+  return {
+    id: edge.id,
+    from: {
+      nodeId: fromNodeId,
+      outPortIdx: fromOutIdx,
+      portId: fromPortId,
+    },
+    to,
+    direction,
+    label,
+    bandwidth,
+    propDelay,
+    packetSize: existing?.packetSize,
+    muPolicy,
+    link: existing?.link,
+    meta: existing?.meta,
+  }
+}
+
+export const attachChannelData = (
+  edges: ReactFlowEdge<ChannelEdgeData>[],
+  nodes: Node<NodeData>[]
+): ReactFlowEdge<ChannelEdgeData>[] => {
+  return edges.map(edge => {
+    const channel = ensureEdgeChannel(edge, nodes)
+    return {
+      ...edge,
+      data: {
+        ...(edge.data ?? {}),
+        channel,
+      },
+    }
+  })
+}
+
+export const estimateServiceRateFromPhysics = (
+  bandwidth?: number,
+  packetSize?: number,
+  propDelay?: number
+): number | null => {
+  const bw = typeof bandwidth === 'number' && bandwidth > 0 ? bandwidth : null
+  const size = typeof packetSize === 'number' && packetSize > 0 ? packetSize : null
+  const delay = typeof propDelay === 'number' && propDelay >= 0 ? propDelay : 0
+  if (!bw || !size) return null
+  const serviceTime = delay + size / bw
+  if (serviceTime <= 0) return null
+  return 1 / serviceTime
+}


### PR DESCRIPTION
## Summary
- extend the channel domain model to carry from/to endpoints, physics options, and link settings
- add helpers to normalize React Flow edges with channel metadata and compute service rates from physics
- replace the PropertiesPanel edge form with a spec-compliant channel editor covering direction, terminals, physics, and link options

## Testing
- npm run test *(fails: vitest CLI requires optional rollup binary that cannot be fetched in the restricted environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb7b8df9588333bb78cf76d5e523b5