### PR TITLE
feat: redesign GPSS modal with searchable dropdowns

### DIFF
--- a/frontend/src/components/GPSSModal.tsx
+++ b/frontend/src/components/GPSSModal.tsx
@@ -1,25 +1,90 @@
-import { useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
+
+type Option = {
+  value: string
+  label: string
+  description?: string
+}
+
+type DistributionParameter = {
+  key: string
+  label: string
+  placeholder?: string
+  description?: string
+}
+
+const distributionParameters: Record<string, DistributionParameter[]> = {
+  uniform: [
+    { key: 'min', label: 'Минимум', placeholder: '0' },
+    { key: 'max', label: 'Максимум', placeholder: '100' },
+  ],
+  exponential: [
+    {
+      key: 'lambda',
+      label: 'Параметр λ',
+      placeholder: '0.5',
+      description: 'Интенсивность экспоненциального распределения.',
+    },
+  ],
+  normal: [
+    { key: 'mean', label: 'Мат. ожидание μ', placeholder: '500' },
+    { key: 'std', label: 'Стандартное отклонение σ', placeholder: '100' },
+  ],
+  lognormal: [
+    { key: 'mu', label: 'μ логнормального распределения', placeholder: '6.2' },
+    { key: 'sigma', label: 'σ логнормального распределения', placeholder: '0.8' },
+  ],
+  erlang: [
+    { key: 'k', label: 'Порядок k', placeholder: '2' },
+    { key: 'rate', label: 'Интенсивность λ', placeholder: '0.5' },
+  ],
+  empirical: [
+    {
+      key: 'reference',
+      label: 'Источник данных',
+      placeholder: 'dataset.csv',
+      description: 'Укажите файл или идентификатор эмпирического распределения.',
+    },
+  ],
+}
+
+const createParametersForDistribution = (
+  distribution: string,
+  previous?: Record<string, string>
+): Record<string, string> => {
+  const params = distributionParameters[distribution] ?? []
+  const next: Record<string, string> = {}
+
+  params.forEach(parameter => {
+    next[parameter.key] = previous?.[parameter.key] ?? ''
+  })
+
+  return next
+}
 
 type ExperimentControl = {
   horizon: string
   timeUnit: string
   replications: string
   aggregationMethod: string
-  warmUp: string
+  warmUpPolicy: string
   resetPolicy: string
   stopCondition: string
 }
 
 type RandomGenerators = {
   baseSeed: string
-  streamSeparation: string
-  reproducibilityPolicy: string
+  seedMode: string
+  streamSeparation: string[]
+  streamPolicy: string
 }
 
 type TrafficCharacteristics = {
   mtu: string
   dataVolumeDistribution: string
-  dataTypesComposition: string
+  dataVolumeParameters: Record<string, string>
+  dataTypesComposition: string[]
+  dataTypeMixMode: string
   roundingPolicy: string
 }
 
@@ -30,13 +95,15 @@ type ServicePolicies = {
 }
 
 type ChannelModel = {
-  defaultThroughput: string
+  defaultThroughputValue: string
+  defaultThroughputUnit: string
   delayFormula: string
+  jitterDistribution: string
   duplexPolicy: string
 }
 
 type StatisticsCollection = {
-  metrics: string
+  metrics: string[]
   aggregationGranularity: string
   counterPrefixes: string
   loggingPolicy: string
@@ -55,52 +122,879 @@ interface Props {
   onClose: () => void
 }
 
+const timeUnitOptions: Option[] = [
+  {
+    value: 'minutes',
+    label: 'минуты Default',
+    description: 'Базовая единица времени — минуты.',
+  },
+  {
+    value: 'seconds',
+    label: 'секунды',
+    description: 'Используйте для более точного временного разрешения.',
+  },
+  {
+    value: 'hours',
+    label: 'часы',
+    description: 'Подходит для длительных сценариев моделирования.',
+  },
+]
+
+const warmUpPolicyOptions: Option[] = [
+  {
+    value: 'no_warmup',
+    label: 'нет прогрева Default',
+    description: 'Стартовые данные учитываются сразу.',
+  },
+  {
+    value: 'fixed_duration',
+    label: 'фиксированная длина',
+    description: 'Прогрев до заранее заданного времени.',
+  },
+  {
+    value: 'steady_state',
+    label: 'до стационарности по метрике',
+    description: 'Завершить прогрев при стабилизации выбранной метрики.',
+  },
+]
+
+const resetPolicyOptions: Option[] = [
+  {
+    value: 'reset_all',
+    label: 'сбросить всё Default',
+    description: 'Обнулить все накопленные показатели.',
+  },
+  {
+    value: 'reset_queues_resources',
+    label: 'сбросить очереди и ресурсы',
+    description: 'Сбросить только показатели очередей и ресурсов.',
+  },
+  {
+    value: 'no_reset',
+    label: 'не сбрасывать',
+    description: 'Сохранять статистику, накопленную во время прогрева.',
+  },
+]
+
+const stopConditionOptions: Option[] = [
+  {
+    value: 'none',
+    label: 'не использовать Default',
+    description: 'Моделирование завершается только по горизонту времени.',
+  },
+  {
+    value: 'processed_requests',
+    label: 'по числу обработанных заявок',
+    description: 'Останов при достижении заданного количества заявок.',
+  },
+  {
+    value: 'lost_packets',
+    label: 'по числу потерянных пакетов',
+    description: 'Контроль по максимально допустимым потерям.',
+  },
+  {
+    value: 'total_system_time',
+    label: 'по суммарному времени в системе',
+    description: 'Завершить при достижении суммарного времени пребывания.',
+  },
+  {
+    value: 'latency_percentile',
+    label: 'по целевому перцентилю задержки (p95/p99)',
+    description: 'Следить за достижением требуемых перцентилей задержки.',
+  },
+  {
+    value: 'metrics_stability',
+    label: 'по стабильности метрик (RSD < 5%)',
+    description: 'Останов при стабилизации относительного разброса.',
+  },
+]
+
+const aggregationOptions: Option[] = [
+  {
+    value: 'mean',
+    label: 'среднее по репликациям Default',
+    description: 'Классическое усреднение по всем прогоном.',
+  },
+  {
+    value: 'median',
+    label: 'медиана',
+    description: 'Устойчивый показатель к выбросам.',
+  },
+  {
+    value: 'trimmed_mean',
+    label: 'усечённое среднее (5%)',
+    description: 'Игнорирует 5% крайних наблюдений.',
+  },
+  {
+    value: 'confidence_interval',
+    label: 'доверительный интервал 95%',
+    description: 'Рассчитать интервал доверия с уровнем 95%.',
+  },
+  {
+    value: 'weighted_mean',
+    label: 'взвешенное среднее по длительности',
+    description: 'Учитывает длительность каждой репликации.',
+  },
+]
+
+const seedModeOptions: Option[] = [
+  {
+    value: 'fixed',
+    label: 'фиксированный Default',
+    description: 'Одинаковый seed во всех запусках.',
+  },
+  {
+    value: 'auto_shift',
+    label: 'автосдвиг на +k для каждой репликации',
+    description: 'Добавлять смещение к seed для каждого повтора.',
+  },
+  {
+    value: 'random',
+    label: 'случайный при каждом запуске',
+    description: 'Новый seed перед каждым запуском модели.',
+  },
+]
+
+const streamSeparationOptions: Option[] = [
+  {
+    value: 'arrivals',
+    label: 'прибытия/генераторы',
+    description: 'Потоки появления заявок и пакетов.',
+  },
+  {
+    value: 'capacity',
+    label: 'объёмы данных (capacity)',
+    description: 'Определение размеров и объёмов пакетов.',
+  },
+  {
+    value: 'interfaces_in',
+    label: 'обслуживание интерфейсов (вход)',
+    description: 'Сервисные времена входящих интерфейсов.',
+  },
+  {
+    value: 'interfaces_out',
+    label: 'обслуживание интерфейсов (выход)',
+    description: 'Сервисные времена исходящих интерфейсов.',
+  },
+  {
+    value: 'node_processing',
+    label: 'обработка узлов (центральная)',
+    description: 'Процессы обработки данных в узлах.',
+  },
+  {
+    value: 'links',
+    label: 'каналы/линки',
+    description: 'Случайность задержек и потерь каналов.',
+  },
+  {
+    value: 'routing',
+    label: 'маршрутизация/ветвления',
+    description: 'Вероятностный выбор направлений.',
+  },
+  {
+    value: 'other',
+    label: 'прочие',
+    description: 'Дополнительные пользовательские подсистемы.',
+  },
+]
+
+const streamPolicyOptions: Option[] = [
+  {
+    value: 'per_subsystem',
+    label: 'каждому подсектору — свой seed Default',
+    description: 'Максимальная независимость потоков случайных чисел.',
+  },
+  {
+    value: 'shared',
+    label: 'общий seed на всё',
+    description: 'Использовать один поток для всех подсистем.',
+  },
+]
+
+const dataVolumeDistributionOptions: Option[] = [
+  {
+    value: 'uniform',
+    label: 'Равномерное Default',
+    description: 'Пакеты равновероятно распределены в заданном диапазоне.',
+  },
+  {
+    value: 'exponential',
+    label: 'Экспоненциальное',
+    description: 'Подходит для моделирования взрывных потоков.',
+  },
+  {
+    value: 'normal',
+    label: 'Нормальное',
+    description: 'Средние значения с симметричным разбросом.',
+  },
+  {
+    value: 'lognormal',
+    label: 'Логнормальное',
+    description: 'Асимметричное распределение объёмов пакетов.',
+  },
+  {
+    value: 'erlang',
+    label: 'Эрланга',
+    description: 'Суперпозиция экспоненциальных фаз.',
+  },
+  {
+    value: 'empirical',
+    label: 'Эмпирическое',
+    description: 'Использовать ранее собранные данные.',
+  },
+]
+
+const dataTypeOptions: Option[] = [
+  {
+    value: 'type1',
+    label: 'type=1',
+    description: 'Базовый тип трафика.',
+  },
+  {
+    value: 'type2',
+    label: 'type=2',
+    description: 'Вторичный тип или класс обслуживания.',
+  },
+  {
+    value: 'custom',
+    label: 'добавить собственный тип',
+    description: 'Определите пользовательский набор параметров.',
+  },
+]
+
+const dataTypeMixOptions: Option[] = [
+  {
+    value: 'equal',
+    label: 'равные доли Default',
+    description: 'Каждый тип получает одинаковую долю.',
+  },
+  {
+    value: 'vector',
+    label: 'по заданному вектору',
+    description: 'Указать веса или вероятности вручную.',
+  },
+  {
+    value: 'empirical',
+    label: 'по эмпирическому распределению',
+    description: 'Загрузить распределение из данных.',
+  },
+]
+
+const roundingPolicyOptions: Option[] = [
+  {
+    value: 'ceil',
+    label: 'вверх (ceil) Default',
+    description: 'Округлять количество пакетов в большую сторону.',
+  },
+  {
+    value: 'round',
+    label: 'математическое округление',
+    description: 'Обычное округление до ближайшего целого.',
+  },
+  {
+    value: 'floor',
+    label: 'вниз (floor)',
+    description: 'Отбрасывать дробную часть в меньшую сторону.',
+  },
+]
+
+const serviceTimeOptions: Option[] = [
+  {
+    value: 'exponential',
+    label: 'Экспоненциальное Default',
+    description: 'Поток обслуживания с памятью нулевой длины.',
+  },
+  {
+    value: 'erlang',
+    label: 'Эрланга(k)',
+    description: 'Более детальное представление сервисного времени.',
+  },
+  {
+    value: 'gamma',
+    label: 'Гамма',
+    description: 'Универсальное распределение положительных значений.',
+  },
+  {
+    value: 'lognormal',
+    label: 'Логнормальное',
+    description: 'Воспроизводит асимметричные хвосты времени.',
+  },
+  {
+    value: 'weibull',
+    label: 'Вэйбулла',
+    description: 'Гибкое распределение для надёжности.',
+  },
+  {
+    value: 'deterministic',
+    label: 'Детерминированное',
+    description: 'Фиксированное время обслуживания.',
+  },
+  {
+    value: 'empirical',
+    label: 'Эмпирическое',
+    description: 'Использовать замеры или исторические данные.',
+  },
+]
+
+const queueDisciplineOptions: Option[] = [
+  {
+    value: 'fifo',
+    label: 'FIFO Default',
+    description: 'Первым пришёл — первым обслужен.',
+  },
+  {
+    value: 'lifo',
+    label: 'LIFO',
+    description: 'Последним пришёл — первым обслужен.',
+  },
+  {
+    value: 'priority_fixed',
+    label: 'приоритетная (fixed)',
+    description: 'Статические приоритеты без вытеснения.',
+  },
+  {
+    value: 'priority_preemptive',
+    label: 'приоритетная (preemptive)',
+    description: 'Высокий приоритет может вытеснить обслуживание.',
+  },
+  {
+    value: 'round_robin',
+    label: 'round-robin',
+    description: 'Квант времени по кругу для каждой очереди.',
+  },
+]
+
+const queueLimitOptions: Option[] = [
+  {
+    value: 'no_limit',
+    label: 'не ограничивать Default',
+    description: 'Очередь может расти без ограничений.',
+  },
+  {
+    value: 'global_limit',
+    label: 'ограничить общим значением',
+    description: 'Один лимит для всех очередей.',
+  },
+  {
+    value: 'resource_class',
+    label: 'по классам ресурсов',
+    description: 'Отдельные лимиты для разных типов ресурсов.',
+  },
+]
+
+const throughputUnitOptions: Option[] = [
+  {
+    value: 'bps',
+    label: 'бит/с Default',
+    description: 'Базовая единица пропускной способности.',
+  },
+  {
+    value: 'kbps',
+    label: 'Кбит/с',
+    description: 'Удобно для типичных сетевых скоростей.',
+  },
+  {
+    value: 'mbps',
+    label: 'Мбит/с',
+    description: 'Популярная единица для магистральных сетей.',
+  },
+  {
+    value: 'gbps',
+    label: 'Гбит/с',
+    description: 'Высокоскоростные каналы и дата-центры.',
+  },
+]
+
+const delayFormulaOptions: Option[] = [
+  {
+    value: 'propagation_only',
+    label: 'только пропагация (S/c) Default',
+    description: 'Учитывается только время распространения.',
+  },
+  {
+    value: 'propagation_and_service',
+    label: 'пропагация + сервис на канале',
+    description: 'Добавляется время передачи по каналу.',
+  },
+  {
+    value: 'mm1',
+    label: 'M/M/1 канал',
+    description: 'Классическая очередь с экспоненциальным обслуживанием.',
+  },
+  {
+    value: 'md1',
+    label: 'M/D/1 канал',
+    description: 'Экспоненциальные прибытия и детерминированный сервис.',
+  },
+  {
+    value: 'custom',
+    label: 'пользовательская формула',
+    description: 'Определяется внешней функцией задержки.',
+  },
+]
+
+const jitterOptions: Option[] = [
+  {
+    value: 'none',
+    label: 'отсутствует Default',
+    description: 'Дополнительный джиттер не учитывается.',
+  },
+  {
+    value: 'uniform',
+    label: 'равномерный',
+    description: 'Варьируется в заданном диапазоне.',
+  },
+  {
+    value: 'normal',
+    label: 'нормальный',
+    description: 'Колебания с симметричным распределением.',
+  },
+  {
+    value: 'lognormal',
+    label: 'логнормальный',
+    description: 'Асимметричное распределение джиттера.',
+  },
+  {
+    value: 'exponential',
+    label: 'экспоненциальный',
+    description: 'Быстрые всплески задержки.',
+  },
+]
+
+const duplexOptions: Option[] = [
+  {
+    value: 'full_duplex',
+    label: 'full-duplex Default',
+    description: 'Передача в обоих направлениях одновременно.',
+  },
+  {
+    value: 'half_duplex',
+    label: 'half-duplex',
+    description: 'Поочерёдное направление передачи.',
+  },
+  {
+    value: 'simplex',
+    label: 'simplex',
+    description: 'Передача только в одном направлении.',
+  },
+]
+
+const metricsOptions: Option[] = [
+  { value: 'avg_delay', label: 'средняя задержка', description: 'Среднее время прохождения пакета.' },
+  { value: 'delay_distribution', label: 'распределение задержки', description: 'Гистограмма задержек.' },
+  { value: 'queue_lengths', label: 'длины очередей', description: 'Динамика длины очередей.' },
+  { value: 'loss_probability', label: 'вероятность потерь', description: 'Оценка вероятности потерь пакетов.' },
+  { value: 'resource_utilization', label: 'загрузка ресурсов', description: 'Процент времени занятости ресурсов.' },
+  { value: 'throughput', label: 'throughput', description: 'Пропускная способность системы.' },
+  { value: 'percentiles', label: 'перцентили p50/p90/p95/p99', description: 'Высокие перцентили задержки.' },
+  { value: 'system_time', label: 'время в системе', description: 'Полное время пребывания пакета.' },
+  { value: 'rsd', label: 'отклонение (RSD)', description: 'Относительное стандартное отклонение.' },
+]
+
+const aggregationGranularityOptions: Option[] = [
+  {
+    value: 'none',
+    label: 'без разбиения Default',
+    description: 'Хранить только агрегированные показатели.',
+  },
+  { value: '1m', label: '1 мин', description: 'Интервал агрегации 1 минута.' },
+  { value: '5m', label: '5 мин', description: 'Интервал агрегации 5 минут.' },
+  { value: '15m', label: '15 мин', description: 'Интервал агрегации 15 минут.' },
+  { value: '60m', label: '60 мин', description: 'Интервал агрегации 60 минут.' },
+  {
+    value: 'custom',
+    label: 'пользовательский шаг',
+    description: 'Задать произвольный интервал агрегации.',
+  },
+]
+
+const loggingPolicyOptions: Option[] = [
+  {
+    value: 'aggregates',
+    label: 'только агрегаты Default',
+    description: 'Сохранять только итоговые показатели.',
+  },
+  {
+    value: 'aggregates_with_queues',
+    label: 'агрегаты + покадровые очереди',
+    description: 'Добавить временные ряды длин очередей.',
+  },
+  {
+    value: 'full',
+    label: 'всё, включая события',
+    description: 'Сохранять полные журналы событий.',
+  },
+  {
+    value: 'disabled',
+    label: 'отключить',
+    description: 'Полностью отключить логирование.',
+  },
+]
+
+const defaultDistribution = 'uniform'
+
 const initialState: FormData = {
   experimentControl: {
     horizon: '',
-    timeUnit: '',
+    timeUnit: 'minutes',
     replications: '',
-    aggregationMethod: '',
-    warmUp: '',
-    resetPolicy: '',
-    stopCondition: '',
+    aggregationMethod: 'mean',
+    warmUpPolicy: 'no_warmup',
+    resetPolicy: 'reset_all',
+    stopCondition: 'none',
   },
   randomGenerators: {
     baseSeed: '',
-    streamSeparation: '',
-    reproducibilityPolicy: '',
+    seedMode: 'fixed',
+    streamSeparation: [],
+    streamPolicy: 'per_subsystem',
   },
   trafficCharacteristics: {
-    mtu: '',
-    dataVolumeDistribution: '',
-    dataTypesComposition: '',
-    roundingPolicy: '',
+    mtu: '65535',
+    dataVolumeDistribution: defaultDistribution,
+    dataVolumeParameters: createParametersForDistribution(defaultDistribution),
+    dataTypesComposition: [],
+    dataTypeMixMode: 'equal',
+    roundingPolicy: 'ceil',
   },
   servicePolicies: {
-    serviceTimeDistribution: '',
-    queueDiscipline: '',
-    queueLimits: '',
+    serviceTimeDistribution: 'exponential',
+    queueDiscipline: 'fifo',
+    queueLimits: 'no_limit',
   },
   channelModel: {
-    defaultThroughput: '',
-    delayFormula: '',
-    duplexPolicy: '',
+    defaultThroughputValue: '',
+    defaultThroughputUnit: 'bps',
+    delayFormula: 'propagation_only',
+    jitterDistribution: 'none',
+    duplexPolicy: 'full_duplex',
   },
   statisticsCollection: {
-    metrics: '',
-    aggregationGranularity: '',
+    metrics: [],
+    aggregationGranularity: 'none',
     counterPrefixes: '',
-    loggingPolicy: '',
+    loggingPolicy: 'aggregates',
   },
+}
+
+function SelectField({
+  label,
+  value,
+  onChange,
+  options,
+  placeholder = 'Выберите…',
+  description,
+  required,
+  error,
+}: {
+  label: string
+  value: string
+  onChange: (value: string) => void
+  options: Option[]
+  placeholder?: string
+  description?: string
+  required?: boolean
+  error?: string
+}) {
+  const [isOpen, setIsOpen] = useState(false)
+  const [search, setSearch] = useState('')
+  const containerRef = useRef<HTMLDivElement | null>(null)
+
+  const selectedOption = options.find(option => option.value === value)
+
+  const filteredOptions = useMemo(() => {
+    const lowerSearch = search.toLowerCase()
+    return options.filter(option => option.label.toLowerCase().includes(lowerSearch))
+  }, [options, search])
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (isOpen && containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setIsOpen(false)
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [isOpen])
+
+  useEffect(() => {
+    if (!isOpen) {
+      setSearch('')
+    }
+  }, [isOpen])
+
+  return (
+    <label className="flex flex-col text-sm">
+      <span className="flex items-center gap-1">
+        {label}
+        {required ? <span className="text-red-500">*</span> : null}
+      </span>
+      <div className="relative mt-1" ref={containerRef}>
+        <button
+          type="button"
+          className={`w-full border rounded px-3 py-2 text-left flex items-center justify-between gap-2 ${
+            error ? 'border-red-500 focus:ring-red-500' : 'border-gray-300'
+          }`}
+          onClick={() => setIsOpen(prev => !prev)}
+        >
+          <span className={selectedOption ? '' : 'text-gray-400'}>
+            {selectedOption ? selectedOption.label : placeholder}
+          </span>
+          <span className="text-gray-400">▾</span>
+        </button>
+        {isOpen ? (
+          <div className="absolute z-20 mt-1 w-full rounded border border-gray-200 bg-white shadow-lg">
+            <div className="p-2 border-b">
+              <input
+                type="text"
+                className="w-full border border-gray-200 rounded px-2 py-1 text-sm"
+                placeholder="Поиск..."
+                value={search}
+                onChange={event => setSearch(event.target.value)}
+              />
+            </div>
+            <ul className="max-h-48 overflow-y-auto py-1 text-sm">
+              {filteredOptions.length ? (
+                filteredOptions.map(option => (
+                  <li key={option.value}>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        onChange(option.value)
+                        setIsOpen(false)
+                      }}
+                      className={`w-full px-3 py-2 text-left hover:bg-blue-50 ${
+                        option.value === value ? 'bg-blue-100' : ''
+                      }`}
+                    >
+                      <div>{option.label}</div>
+                      {option.description ? (
+                        <div className="text-xs text-gray-500">{option.description}</div>
+                      ) : null}
+                    </button>
+                  </li>
+                ))
+              ) : (
+                <li className="px-3 py-2 text-gray-500">Нет совпадений</li>
+              )}
+            </ul>
+          </div>
+        ) : null}
+      </div>
+      {description ? <span className="mt-1 text-xs text-gray-500">{description}</span> : null}
+      {error ? <span className="mt-1 text-xs text-red-600">{error}</span> : null}
+    </label>
+  )
+}
+
+function MultiSelectField({
+  label,
+  value,
+  onChange,
+  options,
+  placeholder = 'Выберите…',
+  description,
+  required,
+  error,
+}: {
+  label: string
+  value: string[]
+  onChange: (value: string[]) => void
+  options: Option[]
+  placeholder?: string
+  description?: string
+  required?: boolean
+  error?: string
+}) {
+  const [isOpen, setIsOpen] = useState(false)
+  const [search, setSearch] = useState('')
+  const containerRef = useRef<HTMLDivElement | null>(null)
+
+  const filteredOptions = useMemo(() => {
+    const lowerSearch = search.toLowerCase()
+    return options.filter(option => option.label.toLowerCase().includes(lowerSearch))
+  }, [options, search])
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (isOpen && containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setIsOpen(false)
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [isOpen])
+
+  useEffect(() => {
+    if (!isOpen) {
+      setSearch('')
+    }
+  }, [isOpen])
+
+  const toggleValue = (optionValue: string) => {
+    onChange(
+      value.includes(optionValue)
+        ? value.filter(item => item !== optionValue)
+        : [...value, optionValue]
+    )
+  }
+
+  const selectedLabels = value
+    .map(item => options.find(option => option.value === item)?.label)
+    .filter((item): item is string => Boolean(item))
+
+  return (
+    <label className="flex flex-col text-sm">
+      <span className="flex items-center gap-1">
+        {label}
+        {required ? <span className="text-red-500">*</span> : null}
+      </span>
+      <div className="relative mt-1" ref={containerRef}>
+        <button
+          type="button"
+          className={`w-full border rounded px-3 py-2 text-left flex items-center justify-between gap-2 ${
+            error ? 'border-red-500 focus:ring-red-500' : 'border-gray-300'
+          }`}
+          onClick={() => setIsOpen(prev => !prev)}
+        >
+          <span className={selectedLabels.length ? '' : 'text-gray-400'}>
+            {selectedLabels.length ? selectedLabels.join(', ') : placeholder}
+          </span>
+          <span className="text-gray-400">▾</span>
+        </button>
+        {isOpen ? (
+          <div className="absolute z-20 mt-1 w-full rounded border border-gray-200 bg-white shadow-lg">
+            <div className="p-2 border-b">
+              <input
+                type="text"
+                className="w-full border border-gray-200 rounded px-2 py-1 text-sm"
+                placeholder="Поиск..."
+                value={search}
+                onChange={event => setSearch(event.target.value)}
+              />
+            </div>
+            <ul className="max-h-48 overflow-y-auto py-1 text-sm">
+              {filteredOptions.length ? (
+                filteredOptions.map(option => {
+                  const isSelected = value.includes(option.value)
+                  return (
+                    <li key={option.value}>
+                      <button
+                        type="button"
+                        onClick={() => toggleValue(option.value)}
+                        className={`w-full px-3 py-2 text-left flex flex-col hover:bg-blue-50 ${
+                          isSelected ? 'bg-blue-100' : ''
+                        }`}
+                      >
+                        <div className="flex items-center gap-2">
+                          <span
+                            className={`inline-flex h-4 w-4 items-center justify-center rounded border text-xs ${
+                              isSelected ? 'border-blue-500 bg-blue-500 text-white' : 'border-gray-300'
+                            }`}
+                          >
+                            {isSelected ? '✓' : ''}
+                          </span>
+                          <span>{option.label}</span>
+                        </div>
+                        {option.description ? (
+                          <div className="ml-6 text-xs text-gray-500">{option.description}</div>
+                        ) : null}
+                      </button>
+                    </li>
+                  )
+                })
+              ) : (
+                <li className="px-3 py-2 text-gray-500">Нет совпадений</li>
+              )}
+            </ul>
+          </div>
+        ) : null}
+      </div>
+      {description ? <span className="mt-1 text-xs text-gray-500">{description}</span> : null}
+      {error ? <span className="mt-1 text-xs text-red-600">{error}</span> : null}
+    </label>
+  )
+}
+
+function NumberInputField({
+  label,
+  value,
+  onChange,
+  required,
+  placeholder,
+  description,
+  error,
+  min,
+}: {
+  label: string
+  value: string
+  onChange: (value: string) => void
+  required?: boolean
+  placeholder?: string
+  description?: string
+  error?: string
+  min?: number
+}) {
+  return (
+    <label className="flex flex-col text-sm">
+      <span className="flex items-center gap-1">
+        {label}
+        {required ? <span className="text-red-500">*</span> : null}
+      </span>
+      <input
+        type="number"
+        min={min}
+        className={`mt-1 border rounded px-3 py-2 ${
+          error ? 'border-red-500 focus:ring-red-500' : 'border-gray-300'
+        }`}
+        value={value}
+        placeholder={placeholder}
+        onChange={event => onChange(event.target.value)}
+      />
+      {description ? <span className="mt-1 text-xs text-gray-500">{description}</span> : null}
+      {error ? <span className="mt-1 text-xs text-red-600">{error}</span> : null}
+    </label>
+  )
+}
+
+function TextInputField({
+  label,
+  value,
+  onChange,
+  description,
+  placeholder,
+}: {
+  label: string
+  value: string
+  onChange: (value: string) => void
+  description?: string
+  placeholder?: string
+}) {
+  return (
+    <label className="flex flex-col text-sm">
+      <span>{label}</span>
+      <input
+        type="text"
+        className="mt-1 border border-gray-300 rounded px-3 py-2"
+        value={value}
+        placeholder={placeholder}
+        onChange={event => onChange(event.target.value)}
+      />
+      {description ? <span className="mt-1 text-xs text-gray-500">{description}</span> : null}
+    </label>
+  )
 }
 
 export default function GPSSModal({ onClose }: Props) {
   const [formData, setFormData] = useState<FormData>(initialState)
+  const [errors, setErrors] = useState<Record<string, string>>({})
 
   const updateField = <K extends keyof FormData, T extends keyof FormData[K]>(
     section: K,
     field: T,
-    value: string
+    value: FormData[K][T]
   ) => {
     setFormData(prev => ({
       ...prev,
@@ -111,7 +1005,66 @@ export default function GPSSModal({ onClose }: Props) {
     }))
   }
 
+  const handleDistributionChange = (value: string) => {
+    setFormData(prev => ({
+      ...prev,
+      trafficCharacteristics: {
+        ...prev.trafficCharacteristics,
+        dataVolumeDistribution: value,
+        dataVolumeParameters: createParametersForDistribution(
+          value,
+          prev.trafficCharacteristics.dataVolumeParameters
+        ),
+      },
+    }))
+  }
+
+  const currentDistributionParameters = useMemo(
+    () =>
+      distributionParameters[
+        formData.trafficCharacteristics.dataVolumeDistribution
+      ] ?? [],
+    [formData.trafficCharacteristics.dataVolumeDistribution]
+  )
+
+  const validate = () => {
+    const newErrors: Record<string, string> = {}
+
+    if (!formData.experimentControl.horizon) {
+      newErrors['experimentControl.horizon'] = 'Укажите горизонт моделирования.'
+    }
+
+    if (!formData.experimentControl.timeUnit) {
+      newErrors['experimentControl.timeUnit'] = 'Выберите единицу времени.'
+    }
+
+    if (!formData.trafficCharacteristics.mtu) {
+      newErrors['trafficCharacteristics.mtu'] = 'Укажите MTU.'
+    }
+
+    if (!formData.trafficCharacteristics.dataVolumeDistribution) {
+      newErrors['trafficCharacteristics.dataVolumeDistribution'] =
+        'Выберите распределение объёма данных.'
+    }
+
+    currentDistributionParameters.forEach(parameter => {
+      if (!formData.trafficCharacteristics.dataVolumeParameters[parameter.key]) {
+        newErrors[`trafficCharacteristics.dataVolumeParameters.${parameter.key}`] =
+          'Заполните параметр распределения.'
+      }
+    })
+
+    setErrors(newErrors)
+    return newErrors
+  }
+
   const handleDownload = () => {
+    const validationResult = validate()
+
+    if (Object.keys(validationResult).length > 0) {
+      return
+    }
+
     const blob = new Blob([JSON.stringify(formData, null, 2)], {
       type: 'application/json',
     })
@@ -147,259 +1100,323 @@ export default function GPSSModal({ onClose }: Props) {
           <section>
             <h3 className="text-lg font-semibold mb-3">Управление экспериментом</h3>
             <div className="grid gap-3 md:grid-cols-2">
-              <label className="flex flex-col text-sm">
-                Горизонт моделирования (временной лимит)
-                <input
-                  type="text"
-                  className="mt-1 border rounded px-3 py-2"
-                  value={formData.experimentControl.horizon}
-                  onChange={e => updateField('experimentControl', 'horizon', e.target.value)}
-                />
-              </label>
-              <label className="flex flex-col text-sm">
-                Единица времени модели (мин/сек/час)
-                <input
-                  type="text"
-                  className="mt-1 border rounded px-3 py-2"
-                  value={formData.experimentControl.timeUnit}
-                  onChange={e => updateField('experimentControl', 'timeUnit', e.target.value)}
-                />
-              </label>
-              <label className="flex flex-col text-sm">
-                Число повторов (replications)
-                <input
-                  type="text"
-                  className="mt-1 border rounded px-3 py-2"
-                  value={formData.experimentControl.replications}
-                  onChange={e => updateField('experimentControl', 'replications', e.target.value)}
-                />
-              </label>
-              <label className="flex flex-col text-sm">
-                Длина прогрева и политика сброса статистики
-                <textarea
-                  className="mt-1 border rounded px-3 py-2"
-                  value={formData.experimentControl.warmUp}
-                  onChange={e => updateField('experimentControl', 'warmUp', e.target.value)}
-                />
-              </label>
-              <label className="flex flex-col text-sm md:col-span-2">
-                Условие останова по счётчику
-                <textarea
-                  className="mt-1 border rounded px-3 py-2"
-                  value={formData.experimentControl.stopCondition}
-                  onChange={e => updateField('experimentControl', 'stopCondition', e.target.value)}
-                />
-              </label>
-              <label className="flex flex-col text-sm">
-                Политика сброса статистики после прогрева
-                <textarea
-                  className="mt-1 border rounded px-3 py-2"
-                  value={formData.experimentControl.resetPolicy}
-                  onChange={e => updateField('experimentControl', 'resetPolicy', e.target.value)}
-                />
-              </label>
-              <label className="flex flex-col text-sm">
-                Способ агрегации результатов
-                <input
-                  type="text"
-                  className="mt-1 border rounded px-3 py-2"
-                  value={formData.experimentControl.aggregationMethod}
-                  onChange={e =>
-                    updateField('experimentControl', 'aggregationMethod', e.target.value)
-                  }
-                />
-              </label>
+              <NumberInputField
+                label="Горизонт моделирования (временной лимит)"
+                required
+                placeholder="В минутах"
+                description="Установите временной лимит моделирования. Значение задаётся в минутах по умолчанию."
+                value={formData.experimentControl.horizon}
+                onChange={value =>
+                  updateField('experimentControl', 'horizon', value)
+                }
+                error={errors['experimentControl.horizon']}
+                min={0}
+              />
+              <SelectField
+                label="Единица времени модели (мин/сек/час)"
+                required
+                value={formData.experimentControl.timeUnit}
+                onChange={value =>
+                  updateField('experimentControl', 'timeUnit', value)
+                }
+                options={timeUnitOptions}
+                description="Определяет единицу времени, в которой задаются параметры модели."
+                error={errors['experimentControl.timeUnit']}
+              />
+              <NumberInputField
+                label="Число повторов (replications)"
+                value={formData.experimentControl.replications}
+                onChange={value =>
+                  updateField('experimentControl', 'replications', value)
+                }
+                description="Количество независимых запусков модели для оценки статистики."
+                placeholder="1"
+                min={0}
+              />
+              <SelectField
+                label="Политика прогрева"
+                value={formData.experimentControl.warmUpPolicy}
+                onChange={value =>
+                  updateField('experimentControl', 'warmUpPolicy', value)
+                }
+                options={warmUpPolicyOptions}
+                description="Выберите политику разгона модели перед сбором статистики."
+              />
+              <SelectField
+                label="Сброс статистики после прогрева"
+                value={formData.experimentControl.resetPolicy}
+                onChange={value =>
+                  updateField('experimentControl', 'resetPolicy', value)
+                }
+                options={resetPolicyOptions}
+                description="Определяет, какие метрики сбрасываются после завершения прогрева."
+              />
+              <SelectField
+                label="Условие останова по счётчику"
+                value={formData.experimentControl.stopCondition}
+                onChange={value =>
+                  updateField('experimentControl', 'stopCondition', value)
+                }
+                options={stopConditionOptions}
+                description="Задайте дополнительное условие остановки модели."
+              />
+              <SelectField
+                label="Способ агрегации результатов"
+                value={formData.experimentControl.aggregationMethod}
+                onChange={value =>
+                  updateField('experimentControl', 'aggregationMethod', value)
+                }
+                options={aggregationOptions}
+                description="Определяет метод обобщения результатов множества прогонов."
+              />
             </div>
           </section>
 
           <section>
             <h3 className="text-lg font-semibold mb-3">Генераторы случайных чисел</h3>
             <div className="grid gap-3 md:grid-cols-2">
-              <label className="flex flex-col text-sm">
-                Базовый seed эксперимента
-                <input
-                  type="text"
-                  className="mt-1 border rounded px-3 py-2"
-                  value={formData.randomGenerators.baseSeed}
-                  onChange={e => updateField('randomGenerators', 'baseSeed', e.target.value)}
-                />
-              </label>
-              <label className="flex flex-col text-sm">
-                Разделение потоков СВ по подсистемам
-                <textarea
-                  className="mt-1 border rounded px-3 py-2"
-                  value={formData.randomGenerators.streamSeparation}
-                  onChange={e =>
-                    updateField('randomGenerators', 'streamSeparation', e.target.value)
-                  }
-                />
-              </label>
-              <label className="flex flex-col text-sm md:col-span-2">
-                Политика воспроизводимости
-                <textarea
-                  className="mt-1 border rounded px-3 py-2"
-                  value={formData.randomGenerators.reproducibilityPolicy}
-                  onChange={e =>
-                    updateField('randomGenerators', 'reproducibilityPolicy', e.target.value)
-                  }
-                />
-              </label>
+              <NumberInputField
+                label="Базовый seed эксперимента"
+                value={formData.randomGenerators.baseSeed}
+                onChange={value =>
+                  updateField('randomGenerators', 'baseSeed', value)
+                }
+                description="Стартовое значение генератора случайных чисел."
+                placeholder="Например, 12345"
+              />
+              <SelectField
+                label="Режим seed"
+                value={formData.randomGenerators.seedMode}
+                onChange={value =>
+                  updateField('randomGenerators', 'seedMode', value)
+                }
+                options={seedModeOptions}
+                description="Определяет стратегию инициализации seed при репликациях."
+              />
+              <MultiSelectField
+                label="Разделение потоков СВ по подсистемам"
+                value={formData.randomGenerators.streamSeparation}
+                onChange={value =>
+                  updateField('randomGenerators', 'streamSeparation', value)
+                }
+                options={streamSeparationOptions}
+                description="Выберите подсистемы, для которых требуется отдельный поток случайных чисел."
+              />
+              <SelectField
+                label="Политика разделения"
+                value={formData.randomGenerators.streamPolicy}
+                onChange={value =>
+                  updateField('randomGenerators', 'streamPolicy', value)
+                }
+                options={streamPolicyOptions}
+                description="Определяет, делить ли seed по подсистемам или использовать общий."
+              />
             </div>
           </section>
 
           <section>
             <h3 className="text-lg font-semibold mb-3">Пакетизация и характеристики трафика</h3>
             <div className="grid gap-3 md:grid-cols-2">
-              <label className="flex flex-col text-sm">
-                MTU (размер пакета, байт)
-                <input
-                  type="text"
-                  className="mt-1 border rounded px-3 py-2"
-                  value={formData.trafficCharacteristics.mtu}
-                  onChange={e => updateField('trafficCharacteristics', 'mtu', e.target.value)}
-                />
-              </label>
-              <label className="flex flex-col text-sm">
-                Распределение объёма передаваемых данных
-                <textarea
-                  className="mt-1 border rounded px-3 py-2"
-                  value={formData.trafficCharacteristics.dataVolumeDistribution}
-                  onChange={e =>
-                    updateField('trafficCharacteristics', 'dataVolumeDistribution', e.target.value)
+              <NumberInputField
+                label="MTU (размер пакета, байт)"
+                required
+                value={formData.trafficCharacteristics.mtu}
+                onChange={value =>
+                  updateField('trafficCharacteristics', 'mtu', value)
+                }
+                description="Максимальный размер пакета. Значение по умолчанию — 65535 байт."
+                placeholder="65535"
+                error={errors['trafficCharacteristics.mtu']}
+                min={0}
+              />
+              <SelectField
+                label="Распределение объёма передаваемых данных"
+                required
+                value={formData.trafficCharacteristics.dataVolumeDistribution}
+                onChange={handleDistributionChange}
+                options={dataVolumeDistributionOptions}
+                description="Тип распределения, определяющий объём данных в пакете."
+                error={errors['trafficCharacteristics.dataVolumeDistribution']}
+              />
+              {currentDistributionParameters.map(parameter => (
+                <NumberInputField
+                  key={parameter.key}
+                  label={parameter.label}
+                  value={
+                    formData.trafficCharacteristics.dataVolumeParameters[
+                      parameter.key
+                    ] ?? ''
+                  }
+                  onChange={value =>
+                    updateField('trafficCharacteristics', 'dataVolumeParameters', {
+                      ...formData.trafficCharacteristics.dataVolumeParameters,
+                      [parameter.key]: value,
+                    })
+                  }
+                  placeholder={parameter.placeholder}
+                  description={parameter.description}
+                  required
+                  error={
+                    errors[
+                      `trafficCharacteristics.dataVolumeParameters.${parameter.key}`
+                    ]
                   }
                 />
-              </label>
-              <label className="flex flex-col text-sm">
-                Состав типов данных и глобальные доли
-                <textarea
-                  className="mt-1 border rounded px-3 py-2"
-                  value={formData.trafficCharacteristics.dataTypesComposition}
-                  onChange={e =>
-                    updateField('trafficCharacteristics', 'dataTypesComposition', e.target.value)
-                  }
-                />
-              </label>
-              <label className="flex flex-col text-sm">
-                Глобальная политика округления числа пакетов
-                <input
-                  type="text"
-                  className="mt-1 border rounded px-3 py-2"
-                  value={formData.trafficCharacteristics.roundingPolicy}
-                  onChange={e =>
-                    updateField('trafficCharacteristics', 'roundingPolicy', e.target.value)
-                  }
-                />
-              </label>
+              ))}
+              <MultiSelectField
+                label="Состав типов данных и глобальные доли"
+                value={formData.trafficCharacteristics.dataTypesComposition}
+                onChange={value =>
+                  updateField('trafficCharacteristics', 'dataTypesComposition', value)
+                }
+                options={dataTypeOptions}
+                description="Выберите глобальные типы данных, присутствующие в модели."
+              />
+              <SelectField
+                label="Режим распределения долей типов данных"
+                value={formData.trafficCharacteristics.dataTypeMixMode}
+                onChange={value =>
+                  updateField('trafficCharacteristics', 'dataTypeMixMode', value)
+                }
+                options={dataTypeMixOptions}
+                description="Определяет, как рассчитываются глобальные доли типов данных."
+              />
+              <SelectField
+                label="Глобальная политика округления числа пакетов"
+                value={formData.trafficCharacteristics.roundingPolicy}
+                onChange={value =>
+                  updateField('trafficCharacteristics', 'roundingPolicy', value)
+                }
+                options={roundingPolicyOptions}
+                description="Правило округления числа пакетов при расчётах."
+              />
             </div>
           </section>
 
           <section>
             <h3 className="text-lg font-semibold mb-3">Политики обслуживания по умолчанию</h3>
             <div className="grid gap-3 md:grid-cols-2">
-              <label className="flex flex-col text-sm">
-                Базовое распределение времен обслуживания
-                <input
-                  type="text"
-                  className="mt-1 border rounded px-3 py-2"
-                  value={formData.servicePolicies.serviceTimeDistribution}
-                  onChange={e =>
-                    updateField('servicePolicies', 'serviceTimeDistribution', e.target.value)
-                  }
-                />
-              </label>
-              <label className="flex flex-col text-sm">
-                Базовая дисциплина очереди и приоритеты
-                <textarea
-                  className="mt-1 border rounded px-3 py-2"
-                  value={formData.servicePolicies.queueDiscipline}
-                  onChange={e =>
-                    updateField('servicePolicies', 'queueDiscipline', e.target.value)
-                  }
-                />
-              </label>
-              <label className="flex flex-col text-sm md:col-span-2">
-                Глобальные верхние пределы длины очередей
-                <textarea
-                  className="mt-1 border rounded px-3 py-2"
-                  value={formData.servicePolicies.queueLimits}
-                  onChange={e => updateField('servicePolicies', 'queueLimits', e.target.value)}
-                />
-              </label>
+              <SelectField
+                label="Базовое распределение времен обслуживания"
+                value={formData.servicePolicies.serviceTimeDistribution}
+                onChange={value =>
+                  updateField('servicePolicies', 'serviceTimeDistribution', value)
+                }
+                options={serviceTimeOptions}
+                description="Выберите распределение для базовых времен обслуживания ресурсов."
+              />
+              <SelectField
+                label="Базовая дисциплина очереди и приоритеты"
+                value={formData.servicePolicies.queueDiscipline}
+                onChange={value =>
+                  updateField('servicePolicies', 'queueDiscipline', value)
+                }
+                options={queueDisciplineOptions}
+                description="Определяет механизм обслуживания в очередях по умолчанию."
+              />
+              <SelectField
+                label="Глобальные верхние пределы длины очередей"
+                value={formData.servicePolicies.queueLimits}
+                onChange={value =>
+                  updateField('servicePolicies', 'queueLimits', value)
+                }
+                options={queueLimitOptions}
+                description="Выберите ограничение на длину очередей в модели."
+              />
             </div>
           </section>
 
           <section>
             <h3 className="text-lg font-semibold mb-3">Канальная модель</h3>
             <div className="grid gap-3 md:grid-cols-2">
-              <label className="flex flex-col text-sm">
-                Глобальная скорость/пропускная способность по умолчанию
-                <input
-                  type="text"
-                  className="mt-1 border rounded px-3 py-2"
-                  value={formData.channelModel.defaultThroughput}
-                  onChange={e =>
-                    updateField('channelModel', 'defaultThroughput', e.target.value)
-                  }
-                />
-              </label>
-              <label className="flex flex-col text-sm">
-                Базовая формула задержки и распределение джиттера
-                <textarea
-                  className="mt-1 border rounded px-3 py-2"
-                  value={formData.channelModel.delayFormula}
-                  onChange={e => updateField('channelModel', 'delayFormula', e.target.value)}
-                />
-              </label>
-              <label className="flex flex-col text-sm md:col-span-2">
-                Политика half/full-duplex и направление по умолчанию
-                <textarea
-                  className="mt-1 border rounded px-3 py-2"
-                  value={formData.channelModel.duplexPolicy}
-                  onChange={e => updateField('channelModel', 'duplexPolicy', e.target.value)}
-                />
-              </label>
+              <NumberInputField
+                label="Глобальная скорость/пропускная способность по умолчанию"
+                value={formData.channelModel.defaultThroughputValue}
+                onChange={value =>
+                  updateField('channelModel', 'defaultThroughputValue', value)
+                }
+                description="Числовое значение пропускной способности."
+                placeholder="Например, 100"
+                min={0}
+              />
+              <SelectField
+                label="Единицы измерения пропускной способности"
+                value={formData.channelModel.defaultThroughputUnit}
+                onChange={value =>
+                  updateField('channelModel', 'defaultThroughputUnit', value)
+                }
+                options={throughputUnitOptions}
+                description="Выберите единицу измерения для указанной пропускной способности."
+              />
+              <SelectField
+                label="Базовая формула задержки"
+                value={formData.channelModel.delayFormula}
+                onChange={value =>
+                  updateField('channelModel', 'delayFormula', value)
+                }
+                options={delayFormulaOptions}
+                description="Определяет основную формулу расчёта задержки в канале."
+              />
+              <SelectField
+                label="Джиттер"
+                value={formData.channelModel.jitterDistribution}
+                onChange={value =>
+                  updateField('channelModel', 'jitterDistribution', value)
+                }
+                options={jitterOptions}
+                description="Выберите распределение вариативности задержки."
+              />
+              <SelectField
+                label="Политика half/full-duplex и направление"
+                value={formData.channelModel.duplexPolicy}
+                onChange={value =>
+                  updateField('channelModel', 'duplexPolicy', value)
+                }
+                options={duplexOptions}
+                description="Режим работы канала по направлению передачи."
+              />
             </div>
           </section>
 
           <section>
             <h3 className="text-lg font-semibold mb-3">Сбор статистики и метрики</h3>
             <div className="grid gap-3 md:grid-cols-2">
-              <label className="flex flex-col text-sm">
-                Перечень собираемых метрик
-                <textarea
-                  className="mt-1 border rounded px-3 py-2"
-                  value={formData.statisticsCollection.metrics}
-                  onChange={e => updateField('statisticsCollection', 'metrics', e.target.value)}
-                />
-              </label>
-              <label className="flex flex-col text-sm">
-                Интервалы/гранулярность агрегации
-                <textarea
-                  className="mt-1 border rounded px-3 py-2"
-                  value={formData.statisticsCollection.aggregationGranularity}
-                  onChange={e =>
-                    updateField('statisticsCollection', 'aggregationGranularity', e.target.value)
-                  }
-                />
-              </label>
-              <label className="flex flex-col text-sm">
-                Имена/префиксы глобальных счётчиков
-                <textarea
-                  className="mt-1 border rounded px-3 py-2"
-                  value={formData.statisticsCollection.counterPrefixes}
-                  onChange={e =>
-                    updateField('statisticsCollection', 'counterPrefixes', e.target.value)
-                  }
-                />
-              </label>
-              <label className="flex flex-col text-sm">
-                Политика логирования
-                <textarea
-                  className="mt-1 border rounded px-3 py-2"
-                  value={formData.statisticsCollection.loggingPolicy}
-                  onChange={e => updateField('statisticsCollection', 'loggingPolicy', e.target.value)}
-                />
-              </label>
+              <MultiSelectField
+                label="Перечень собираемых метрик"
+                value={formData.statisticsCollection.metrics}
+                onChange={value =>
+                  updateField('statisticsCollection', 'metrics', value)
+                }
+                options={metricsOptions}
+                description="Выберите показатели, которые следует собирать во время моделирования."
+              />
+              <SelectField
+                label="Интервалы/гранулярность агрегации"
+                value={formData.statisticsCollection.aggregationGranularity}
+                onChange={value =>
+                  updateField('statisticsCollection', 'aggregationGranularity', value)
+                }
+                options={aggregationGranularityOptions}
+                description="Определяет шаг агрегации метрик."
+              />
+              <TextInputField
+                label="Имена/префиксы глобальных счётчиков"
+                value={formData.statisticsCollection.counterPrefixes}
+                onChange={value =>
+                  updateField('statisticsCollection', 'counterPrefixes', value)
+                }
+                description="Необязательный текстовый префикс для глобальных счётчиков."
+                placeholder="global_"
+              />
+              <SelectField
+                label="Политика логирования"
+                value={formData.statisticsCollection.loggingPolicy}
+                onChange={value =>
+                  updateField('statisticsCollection', 'loggingPolicy', value)
+                }
+                options={loggingPolicyOptions}
+                description="Уровень детализации журналов моделирования."
+              />
             </div>
           </section>
         </div>
@@ -417,7 +1434,7 @@ export default function GPSSModal({ onClose }: Props) {
             className="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700"
             onClick={handleDownload}
           >
-            МОДЕЛТРОВАТЬ
+            МОДЕЛИРОВАТЬ
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- replace free-form GPSS fields with reusable searchable select and multi-select widgets
- add validation for required GPSS parameters and defaulted option sets per specification
- extend channel, traffic, RNG, and statistics sections with structured dropdown choices and hints

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcc8bb7b54832c931d7b3a7215bf94